### PR TITLE
Use with-associations option for the generated track_associations...

### DIFF
--- a/lib/generators/paper_trail/install_generator.rb
+++ b/lib/generators/paper_trail/install_generator.rb
@@ -45,7 +45,7 @@ module PaperTrail
     def create_initializer
       create_file(
         "config/initializers/paper_trail.rb",
-        "PaperTrail.config.track_associations = true\n",
+        "PaperTrail.config.track_associations = #{!!options.with_associations?}\n",
         "PaperTrail.config.association_reify_error_behaviour = :error"
       )
     end


### PR DESCRIPTION
...initializer.

It appears that #1091 introduced this unintentionally by moving the initializer generator into a conditional in https://github.com/paper-trail-gem/paper_trail/pull/1091/commits/f9a8a777a0e5bd16f696cb421c79ef57802aa41b#diff-385d0586e82e9b33429c177d016048af but when it was finally merged in under d056c7e13b3a35ee79f490e8d82ea13d5fe8cf22 that conditional was removed but the interpolated `with_associations?` option was never added back.

This means that if you use the default behavior of not using the with-associations option when running the install generator, you still get `PaperTrail.config.track_associations = true` in your generated initializer even though none of the other migration files, etc are generated so `Could not find table 'version_associations'` is raised when saving any model versioned through paper trail.