### PR TITLE
Readme fix: caller.find {} rather than caller.first {}

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ required.
 
 ```ruby
 PaperTrail.request.whodunnit = proc do
-  caller.first{ |c| c.starts_with? Rails.root.to_s }
+  caller.find { |c| c.starts_with? Rails.root.to_s }
 end
 ```
 


### PR DESCRIPTION
(`Array#first` doesn't take a block, so it was the same as just calling `caller.first`.)