### PR TITLE
Provide Gem-Level Option To Ignore timestamp_update_attr Only Changes

### DIFF
--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -21,7 +21,8 @@ module PaperTrail
       :association_reify_error_behaviour,
       :object_changes_adapter,
       :serializer,
-      :version_limit
+      :version_limit,
+      :ignore_update_timestamp_only_changes
     )
 
     def initialize

--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -32,11 +32,13 @@ module PaperTrail
 
       # Determines whether it is appropriate to generate a new version
       # instance. A timestamp-only update (e.g. only `updated_at` changed) is
-      # considered notable unless an ignored attribute was also changed.
+      # considered notable unless an ignored attribute was also changed or we
+      # explicitly set `ignore_update_timestamp_only_changes` property in
+      # papertrail configs
       #
       # @api private
       def changed_notably?
-        if ignored_attr_has_changed?
+        if ignored_attr_has_changed? || PaperTrail.config.ignore_update_timestamp_only_changes
           timestamps = @record.send(:timestamp_attributes_for_update_in_model).map(&:to_s)
           (notably_changed - timestamps).any?
         else

--- a/spec/paper_trail/events/base_spec.rb
+++ b/spec/paper_trail/events/base_spec.rb
@@ -47,6 +47,34 @@ module PaperTrail
             expect(event.changed_notably?).to eq(false)
           end
         end
+
+        context "persisted record with update timestamps only" do
+          context "ignore_timestamp_only_updates is set to true" do
+            before do
+              PaperTrail.config.ignore_update_timestamp_only_changes = true
+            end
+
+            after do
+              PaperTrail.config.ignore_update_timestamp_only_changes = false
+            end
+
+            it "does not acknowledge timestamp-attrs change" do
+              gadget = Gadget.create!(created_at: Time.now)
+              gadget.updated_at = Time.now
+              event = PaperTrail::Events::Base.new(gadget, false)
+              expect(event.changed_notably?).to eq(false)
+            end
+          end
+
+          context "ignore_timestamp_only_updates is set to false (default)" do
+            it "acknowledges timestamp-attrs change" do
+              gadget = Gadget.create!(created_at: Time.now)
+              gadget.updated_at = Time.now
+              event = PaperTrail::Events::Base.new(gadget, false)
+              expect(event.changed_notably?).to eq(true)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Actions like #touch in active record models, in some cases, only yield an `updated_at` value change (or whatever the timestamp_update_attribute name is). As a developer, it would be useful to provide the option to skip generating/inserting versions records for these updates.