### PR TITLE
Add the ability to pass options to the has_many :versions association macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- [#1158](https://github.com/paper-trail-gem/paper_trail/pull/1158) — Add the ability to pass
+  options, such as `scope` or `extend:` to the `has_many :versions` association macro.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - None
 
+### Deprecated
+
+- [#1158](https://github.com/paper-trail-gem/paper_trail/pull/1158) — Passing association name as
+  `versions:` option or Version class name as `class_name:` options directly to `has_paper_trail`.
+  Use `has_paper_trail versions: {name: :drafts, class_name: "MyVersionModel"}` instead.
+
 ### Added
 
 - [#1158](https://github.com/paper-trail-gem/paper_trail/pull/1158) — Add the ability to pass

--- a/README.md
+++ b/README.md
@@ -955,7 +955,7 @@ see https://github.com/paper-trail-gem/paper_trail/issues/594
 ### 5.b. Configuring the `versions` Association
 
 You may configure the name of the `versions` association by passing
-a different name to `has_paper_trail`.
+a different name to `has_paper_trail`:
 
 ```ruby
 class Post < ActiveRecord::Base
@@ -967,6 +967,23 @@ Post.new.versions # => NoMethodError
 
 Overriding (instead of configuring) the `versions` method is not supported.
 Overriding associations is not recommended in general.
+
+You may pass other options for the `has_many` by passing a hash of options:
+
+```ruby
+class Post < ActiveRecord::Base
+  has_paper_trail versions: {
+    name: :drafts,
+    scope: -> { order("id desc") },
+    extend: VersionsExtensions
+  }
+end
+```
+
+Refer to
+https://api.rubyonrails.org/classes/ActiveRecord/Associations/ClassMethods.html#method-i-has_many-label-Options
+for the full list of supported options for `has_many`.
+
 
 ### 5.c. Generators
 

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -138,10 +138,7 @@ module PaperTrail
       # @api public
       @model_class.send :attr_accessor, @model_class.version_association_name
 
-      # @api private - `version_class_name` - However, `rails_admin` has been
-      # using it since 2014 (see `rails_admin/extensions/paper_trail/auditing_adapter.rb`,
-      # https://github.com/sferik/rails_admin/commit/959e1bd4e47e0369d264b58bbbe972ff863767cd)
-      # In PR _____ () we ask them to use `paper_trail_options` instead.
+      # @api private - `version_class_name`
       @model_class.class_attribute :version_class_name
       @model_class.version_class_name = options[:class_name] || "PaperTrail::Version"
 

--- a/spec/dummy_app/app/models/concerns/prefix_versions_inspect_with_count.rb
+++ b/spec/dummy_app/app/models/concerns/prefix_versions_inspect_with_count.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module PrefixVersionsInspectWithCount
+  def inspect
+    "#{length} versions:\n" +
+      super
+  end
+end

--- a/spec/dummy_app/app/models/custom_primary_key_record.rb
+++ b/spec/dummy_app/app/models/custom_primary_key_record.rb
@@ -5,7 +5,7 @@ require "securerandom"
 class CustomPrimaryKeyRecord < ActiveRecord::Base
   self.primary_key = :uuid
 
-  has_paper_trail class_name: "CustomPrimaryKeyRecordVersion"
+  has_paper_trail versions: { class_name: "CustomPrimaryKeyRecordVersion" }
 
   # This default_scope is to test the case of the Version#item association
   # not returning the item due to unmatched default_scope on the model.

--- a/spec/dummy_app/app/models/document.rb
+++ b/spec/dummy_app/app/models/document.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# Demonstrates a "custom versions association name". Instead of the assication
+# Demonstrates a "custom versions association name". Instead of the association
 # being named `versions`, it will be named `paper_trail_versions`.
 class Document < ActiveRecord::Base
   has_paper_trail(
-    versions: :paper_trail_versions,
+    versions: { name: :paper_trail_versions },
     on: %i[create update]
   )
 end

--- a/spec/dummy_app/app/models/fruit.rb
+++ b/spec/dummy_app/app/models/fruit.rb
@@ -2,6 +2,6 @@
 
 class Fruit < ActiveRecord::Base
   if ENV["DB"] == "postgres" || JsonVersion.table_exists?
-    has_paper_trail class_name: "JsonVersion"
+    has_paper_trail versions: { class_name: "JsonVersion" }
   end
 end

--- a/spec/dummy_app/app/models/kitchen/banana.rb
+++ b/spec/dummy_app/app/models/kitchen/banana.rb
@@ -2,6 +2,6 @@
 
 module Kitchen
   class Banana < ActiveRecord::Base
-    has_paper_trail class_name: "Kitchen::BananaVersion"
+    has_paper_trail versions: { class_name: "Kitchen::BananaVersion" }
   end
 end

--- a/spec/dummy_app/app/models/no_object.rb
+++ b/spec/dummy_app/app/models/no_object.rb
@@ -3,7 +3,7 @@
 # Demonstrates a table that omits the `object` column.
 class NoObject < ActiveRecord::Base
   has_paper_trail(
-    class_name: "NoObjectVersion",
+    versions: { class_name: "NoObjectVersion" },
     meta: { metadatum: 42 }
   )
   validates :letter, length: { is: 1 }, presence: true

--- a/spec/dummy_app/app/models/post.rb
+++ b/spec/dummy_app/app/models/post.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Post < ActiveRecord::Base
-  has_paper_trail class_name: "PostVersion"
+  has_paper_trail versions: { class_name: "PostVersion" }
 end

--- a/spec/dummy_app/app/models/thing.rb
+++ b/spec/dummy_app/app/models/thing.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class Thing < ActiveRecord::Base
-  has_paper_trail
+  has_paper_trail versions: {
+    extend: PrefixVersionsInspectWithCount,
+    scope: -> { order("id desc") }
+  }
 
   if ActiveRecord.gem_version >= Gem::Version.new("5.0")
     belongs_to :person, optional: true

--- a/spec/models/thing_spec.rb
+++ b/spec/models/thing_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Thing, type: :model do
+  describe "#versions", versioning: true do
+    let(:thing) { Thing.create! }
+
+    it "applies the extend option" do
+      expect(thing.versions.singleton_class).to be < PrefixVersionsInspectWithCount
+      expect(thing.versions.inspect).to start_with("1 versions:")
+    end
+
+    it "applies the scope option" do
+      expect(Thing.reflect_on_association(:versions).scope).to be_a Proc
+      expect(thing.versions.to_sql).to end_with "ORDER BY id desc"
+    end
+  end
+end

--- a/spec/paper_trail/model_config_spec.rb
+++ b/spec/paper_trail/model_config_spec.rb
@@ -4,15 +4,58 @@ require "spec_helper"
 
 module PaperTrail
   ::RSpec.describe ModelConfig do
-    describe "when has_paper_trail is called" do
-      it "raises an error" do
-        expect {
-          class MisconfiguredCVC < ActiveRecord::Base
-            has_paper_trail class_name: "AbstractVersion"
+    describe "has_paper_trail" do
+      describe "passing an abstract class to class_name" do
+        it "raises an error" do
+          expect {
+            Class.new(ActiveRecord::Base) do
+              has_paper_trail class_name: "AbstractVersion"
+            end
+          }.to raise_error(
+            /use concrete \(not abstract\) version models/
+          )
+        end
+      end
+
+      describe "versions:" do
+        it "name can be passed instead of an options hash" do
+          klass = Class.new(ActiveRecord::Base) do
+            has_paper_trail versions: :drafts
           end
-        }.to raise_error(
-          /use concrete \(not abstract\) version models/
-        )
+          expect(klass.reflect_on_association(:drafts)).to be_a(
+            ActiveRecord::Reflection::HasManyReflection
+          )
+        end
+        it "name can be passed in the options hash" do
+          klass = Class.new(ActiveRecord::Base) do
+            has_paper_trail versions: { name: :drafts }
+          end
+          expect(klass.reflect_on_association(:drafts)).to be_a(
+            ActiveRecord::Reflection::HasManyReflection
+          )
+        end
+        it "allows any option that has_many supports" do
+          klass = Class.new(ActiveRecord::Base) do
+            has_paper_trail versions: { autosave: true, validate: true }
+          end
+          expect(klass.reflect_on_association(:versions).options[:autosave]).to eq true
+          expect(klass.reflect_on_association(:versions).options[:validate]).to eq true
+        end
+        it "can even override options that PaperTrail adds to has_many" do
+          klass = Class.new(ActiveRecord::Base) do
+            has_paper_trail versions: { as: :foo }
+          end
+          expect(klass.reflect_on_association(:versions).options[:as]).to eq :foo
+        end
+        it "raises an error on unknown has_many options" do
+          expect {
+            Class.new(ActiveRecord::Base) do
+              has_paper_trail versions: { read_my_mind: true, validate: true }
+            end
+          }.to raise_error(
+            /Unknown key: :read_my_mind. Valid keys are: .*:class_name,/
+          )
+        end
       end
     end
   end

--- a/spec/support/alt_db_init.rb
+++ b/spec/support/alt_db_init.rb
@@ -33,7 +33,7 @@ module Foo
   end
 
   class Document < Base
-    has_paper_trail class_name: "Foo::Version"
+    has_paper_trail versions: { class_name: "Foo::Version" }
   end
 end
 
@@ -52,7 +52,7 @@ module Bar
   end
 
   class Document < Base
-    has_paper_trail class_name: "Bar::Version"
+    has_paper_trail versions: { class_name: "Bar::Version" }
   end
 end
 


### PR DESCRIPTION
Users can already customize some aspects of the `has_many :versions` association, including the association name (via `:versions` option) and the class name (via `:class_name` option).

This changeset allows other [options](https://api.rubyonrails.org/v5.2/classes/ActiveRecord/Associations/ClassMethods.html#method-i-has_many-label-Options), such as `:extend`, to be passed on to this `has_many`.