### PR TITLE
Fix typo: `seperate` -> `separate`

### DIFF
--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -10,7 +10,7 @@ module PaperTrail
     include Singleton
 
     E_PT_AT_REMOVED = <<-EOS.squish
-      Association Tracking for PaperTrail has been extracted to a seperate gem.
+      Association Tracking for PaperTrail has been extracted to a separate gem.
       To use it, please add `paper_trail-association_tracking` to your Gemfile.
       If you don't use it (most people don't, that's the default) and you set
       `track_associations = false` somewhere (probably a rails initializer) you


### PR DESCRIPTION
Just fixed a typo.