### PR TITLE
Add configurable "default_events" to allow tailoring which events are active on unqualified has_paper_trail declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- New configurable `default_events` defines which events are enabled by default.  
+  Example:
 
+  ```PaperTrail.config.default_events = %i[ create update destroy ]  # Skip touch events by default```  
+
+  If not set, the default is `%i[ create update destroy touch ]`.  As before, you can override the enabled events on a per-model basis with `has_paper_trail on: [ events.....]`
 ### Fixed
 
 - None

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -21,7 +21,8 @@ module PaperTrail
       :association_reify_error_behaviour,
       :object_changes_adapter,
       :serializer,
-      :version_limit
+      :version_limit,
+      :default_events
     )
 
     def initialize
@@ -31,6 +32,7 @@ module PaperTrail
 
       # Variables which affect all threads, whose access is *not* synchronized.
       @serializer = PaperTrail::Serializers::YAML
+      @default_events = %i[create update destroy touch]
     end
 
     # Indicates whether PaperTrail is on or off. Default: true.

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -97,7 +97,7 @@ module PaperTrail
     # "class attributes", instance methods, and more.
     # @api private
     def setup(options = {})
-      options[:on] ||= %i[create update destroy touch]
+      options[:on] ||= PaperTrail.config.default_events
       options[:on] = Array(options[:on]) # Support single symbol
       @model_class.send :include, ::PaperTrail::Model::InstanceMethods
       setup_options(options)


### PR DESCRIPTION
Thank you for your contribution!

Check the following boxes:

- [X] Wrote [good commit messages][1].
- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
