### PR TITLE
Readme doesn't say generator creates initialiser

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ has been destroyed.
 
     `gem 'paper_trail'`
 
-1. Add a `versions` table to your database and an initializer file for configuration:
+1. Add a `versions` table to your database:
 
     ```
     bundle exec rails generate paper_trail:install [--with-changes] [--with-associations]
@@ -988,7 +988,7 @@ for the full list of supported options for `has_many`.
 ### 5.c. Generators
 
 PaperTrail has one generator, `paper_trail:install`. It writes, but does not
-run, a migration file.  It also creates a PaperTrail configuration initializer.
+run, a migration file.
 The migration adds (at least) the `versions` table. The
 most up-to-date documentation for this generator can be found by running `rails
 generate paper_trail:install --help`, but a copy is included here for
@@ -1007,7 +1007,7 @@ Runtime options:
   -q, [--quiet], [--no-quiet]      # Suppress status output
   -s, [--skip], [--no-skip]        # Skip files that already exist
 
-Generates (but does not run) a migration to add a versions table.  Also generates an initializer file for configuring PaperTrail
+Generates (but does not run) a migration to add a versions table.
 ```
 
 ### 5.d. Protected Attributes

--- a/lib/generators/paper_trail/install/install_generator.rb
+++ b/lib/generators/paper_trail/install/install_generator.rb
@@ -22,7 +22,6 @@ module PaperTrail
     )
 
     desc "Generates (but does not run) a migration to add a versions table." \
-         "  Also generates an initializer file for configuring PaperTrail." \
          "  See section 5.c. Generators in README.md for more information."
 
     def create_migration_file

--- a/lib/generators/paper_trail/install_generator.rb
+++ b/lib/generators/paper_trail/install_generator.rb
@@ -24,8 +24,7 @@ module PaperTrail
       desc: "Store changeset (diff) with each version"
     )
 
-    desc "Generates (but does not run) a migration to add a versions table." \
-         "  Also generates an initializer file for configuring PaperTrail"
+    desc "Generates (but does not run) a migration to add a versions table."
 
     def create_migration_file
       add_paper_trail_migration("create_versions")


### PR DESCRIPTION
Fixes #1163 

As of 1d42d0d0ab1537123b115e4217badec0ad165a61 the generator does not create an initializer.

This seems to have been unintentional, but it isn't actually required for PaperTrail to run correctly and there are [no plans to reinstate it](https://github.com/paper-trail-gem/paper_trail/issues/1163#issuecomment-435079777) so it's best to remove references to it from the documentation.

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

_The last box isn't checked since the title can't be both grammatically correct, and sufficiently short to be an acceptable commit title_

[1]: http://chris.beams.io/posts/git-commit/
