### PR TITLE
dummy_app is compatible with paper_trail-association_tracking v1.1.0

### DIFF
--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -36,7 +36,7 @@ has been destroyed.
   s.add_development_dependency "ffaker", "~> 2.8"
   s.add_development_dependency "generator_spec", "~> 0.9.4"
   s.add_development_dependency "mysql2", "~> 0.5.2"
-  s.add_development_dependency "paper_trail-association_tracking", "< 1.1"
+  s.add_development_dependency "paper_trail-association_tracking", "~> 1.1.0"
   s.add_development_dependency "pg", "~> 1.0"
   s.add_development_dependency "rake", "~> 12.3"
   s.add_development_dependency "rspec-rails", "~> 3.8"

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -105,10 +105,11 @@ class SetUpTestTables < (
       t.integer  :version_id
       t.string   :foreign_key_name, null: false
       t.integer  :foreign_key_id
+      t.string   :foreign_type, null: false
     end
     add_index :version_associations, [:version_id]
     add_index :version_associations,
-      %i[foreign_key_name foreign_key_id],
+      %i[foreign_key_name foreign_key_id foreign_type],
       name: "index_version_associations_on_foreign_key"
 
     create_table :post_versions, force: true do |t|


### PR DESCRIPTION
New version of paper_trail-association_tracking (1.1.0) requires `foreign_type` column in `version_associations` table to support polymorphic has_many associations.

ref: https://github.com/westonganger/paper_trail-association_tracking/commit/8cd2f3ea421615f7b08a3ba5b369ca1ff58ea0a7#diff-5202d4561c456760f41eb3fd3e53193b

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
