### PR TITLE
update readme for disabling papertrail within initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,6 @@ Syntax example: (options described in detail later)
 
 ```ruby
 # config/initializers/paper_trail.rb
-PaperTrail.config.enabled = true
 PaperTrail.config.has_paper_trail_defaults = {
   on: %i[create update destroy]
 }
@@ -292,9 +291,14 @@ PaperTrail.config.version_limit = 3
 ````
 
 These options are intended to be set only once, during app initialization (eg.
-in `config/initializers`). It is unsafe to change them while the app is running.
+in `config/initializers` or in an environment-specific configuration file such as
+`config/environments/test.rb`). It is unsafe to change them while the app is running.
 In contrast, `PaperTrail.request` has various options that only apply to a
 single HTTP request and thus are safe to use while the app is running.
+
+Note that `PaperTrails.config.enabled` will be overwritten if it is set within
+`config/initializers`. For more information, see
+[Turning PaperTrail Off](#2d-turning-papertrail-off) below.
 
 ## 2. Limiting What is Versioned, and When
 
@@ -502,6 +506,11 @@ PaperTrail.enabled = false
 
 **Do not use this in production** unless you have a good understanding of
 threads vs. processes.
+
+Also note that PaperTrail can only be disabled globally during or after
+environment-specific initialization. In other words, changes to
+`PaperTrail.enabled` (or its alias `PaperTrail.config.enabled`) in
+`config/initializers` will be overwritten.
 
 A legitimate use case is to speed up tests. See [Testing](#7-testing) below.
 


### PR DESCRIPTION
Fixes #1038 

Updating the readme to clarify that `PaperTrail.config.enabled` cannot be set within an initializer since it's eventually overwritten by the environment-specific config (or by the internal default of `true`).

I tried to be clear without giving unnecessary details. Also tried to use style consistent with the rest of the readme, but please let me know if you have suggestions.

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.