### PR TITLE
fix: do not store ignored and skipped attributes in `object_changes` on destroy

### DIFF
--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -106,16 +106,9 @@ module PaperTrail
         (changed_in_latest_version - ignore) - skip
       end
 
-      # Rails 5.1 changed the API of `ActiveRecord::Dirty`. See
-      # https://github.com/paper-trail-gem/paper_trail/pull/899
-      #
       # @api private
       def changed_in_latest_version
-        if @in_after_callback && RAILS_GTE_5_1
-          @record.saved_changes.keys
-        else
-          @record.changed
-        end
+        changes_in_latest_version.keys
       end
 
       # @api private

--- a/lib/paper_trail/events/destroy.rb
+++ b/lib/paper_trail/events/destroy.rb
@@ -22,12 +22,17 @@ module PaperTrail
           data[:object] = recordable_object(false)
         end
         if record_object_changes?
-          # Rails' implementation returns nothing on destroy :/
-          changes = @record.attributes.map { |attr, value| [attr, [value, nil]] }.to_h
-          data[:object_changes] = prepare_object_changes(changes)
+          data[:object_changes] = prepare_object_changes(notable_changes)
         end
         merge_item_subtype_into(data)
         merge_metadata_into(data)
+      end
+
+      private
+
+      # Rails' implementation returns nothing on destroy :/
+      def changes_in_latest_version
+        @record.attributes.map { |attr, value| [attr, [value, nil]] }.to_h
       end
     end
   end

--- a/spec/paper_trail/events/destroy_spec.rb
+++ b/spec/paper_trail/events/destroy_spec.rb
@@ -15,6 +15,28 @@ module PaperTrail
           expect(data[:item_type]).to eq("Family::Family")
           expect(data[:item_subtype]).to eq("Family::CelebrityFamily")
         end
+
+        context "skipper" do
+          let(:skipper) { Skipper.create!(another_timestamp: Time.now) }
+          let(:data) { PaperTrail::Events::Destroy.new(skipper, false).data }
+
+          it "includes `object` without skipped attributes" do
+            object = YAML.load(data[:object])
+            expect(object["id"]).to eq(skipper.id)
+            expect(object).to have_key("updated_at")
+            expect(object).to have_key("created_at")
+            expect(object).not_to have_key("another_timestamp")
+          end
+
+          it "includes `object_changes` without skipped and ignored attributes" do
+            changes = YAML.load(data[:object_changes])
+            expect(changes["id"]).to eq([skipper.id, nil])
+            expect(changes["updated_at"][0]).to be_present
+            expect(changes["updated_at"][1]).to be_nil
+            expect(changes).not_to have_key("created_at")
+            expect(changes).not_to have_key("another_timestamp")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
I think skipped and ignored attributes should be ignored in `object_changes` on `destroy` (same way as on `create` and `update`). This PR fixes that.

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
