### PR TITLE
No need to calculate previous values of skipped attributes

### DIFF
--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -59,8 +59,10 @@ module PaperTrail
       end
 
       # @api private
-      def attributes_before_change(is_touch)
-        Hash[@record.attributes.map do |k, v|
+      def nonskipped_attributes_before_change(is_touch)
+        record_attributes = @record.attributes.except(*@record.paper_trail_options[:skip])
+
+        Hash[record_attributes.map do |k, v|
           if @record.class.column_names.include?(k)
             [k, attribute_in_previous_version(k, is_touch)]
           else
@@ -217,8 +219,7 @@ module PaperTrail
       #
       # @api private
       def object_attrs_for_paper_trail(is_touch)
-        attrs = attributes_before_change(is_touch).
-          except(*@record.paper_trail_options[:skip])
+        attrs = nonskipped_attributes_before_change(is_touch)
         AttributeSerializers::ObjectAttribute.new(@record.class).serialize(attrs)
         attrs
       end

--- a/spec/paper_trail/events/base_spec.rb
+++ b/spec/paper_trail/events/base_spec.rb
@@ -48,6 +48,17 @@ module PaperTrail
           end
         end
       end
+
+      describe "#nonskipped_attributes_before_change", versioning: true do
+        subject { event.send(:nonskipped_attributes_before_change, false) }
+
+        let(:event) { PaperTrail::Events::Base.new(skipper, false) }
+        let(:skipper) { Skipper.create!(another_timestamp: Time.now) }
+
+        it do
+          is_expected.not_to have_key("another_timestamp")
+        end
+      end
     end
   end
 end

--- a/spec/paper_trail/serializer_spec.rb
+++ b/spec/paper_trail/serializer_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe(PaperTrail, versioning: true) do
       customer = Customer.create(name: "Some text.")
       original_attributes = PaperTrail::Events::Base.
         new(customer, false).
-        send(:attributes_before_change, false)
+        send(:nonskipped_attributes_before_change, false)
       customer.update(name: "Some more text.")
       expect(customer.versions.length).to(eq(2))
       expect(customer.versions[0].reify).to(be_nil)
@@ -34,7 +34,7 @@ RSpec.describe(PaperTrail, versioning: true) do
       customer = Customer.create(name: "Some text.")
       original_attributes = PaperTrail::Events::Base.
         new(customer, false).
-        send(:attributes_before_change, false)
+        send(:nonskipped_attributes_before_change, false)
       customer.update(name: "Some more text.")
       expect(customer.versions.length).to(eq(2))
       expect(customer.versions[0].reify).to(be_nil)
@@ -68,7 +68,7 @@ RSpec.describe(PaperTrail, versioning: true) do
       customer = Customer.create
       original_attributes = PaperTrail::Events::Base.
         new(customer, false).
-        send(:attributes_before_change, false).
+        send(:nonskipped_attributes_before_change, false).
         reject { |_k, v| v.nil? }
       customer.update(name: "Some more text.")
       expect(customer.versions.length).to(eq(2))


### PR DESCRIPTION
I'm going to remove a column of one model. I want to make sure that no one calls it anymore before removing it, so I overwritted it as below:
```rb
def my_column
  fail 'should not be called'
end
```

But `paper_trail` will call it even the attribute is skipped.
It calculates all attributes and then filters out skipped attributes.
https://github.com/paper-trail-gem/paper_trail/blob/85884ba06c1eefbc76114d70c4f8f05791f5659a/lib/paper_trail/events/base.rb#L219-L221

The flow can be improved to calculate only non-skipped attributes.

- [X] Wrote [good commit messages][1].
- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
