### PR TITLE
Lower the memory allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 - [#1184](https://github.com/paper-trail-gem/paper_trail/pull/1184) -
   No need to calculate previous values of skipped attributes
 
+- [#1188](https://github.com/paper-trail-gem/paper_trail/pull/1188) -
+  Optimized the memory allocations during the building of every particular
+  Version object. That can help a lot for heavy bulk processing.
+  In additional we advise to use `json[b]` DB types for `object`
+  and `object_changes` Version columns, in order to reach best possible
+  RAM performance.
+
 ## 10.2.0 (2019-01-31)
 
 ### Breaking Changes

--- a/lib/paper_trail/events/create.rb
+++ b/lib/paper_trail/events/create.rb
@@ -13,6 +13,7 @@ module PaperTrail
       # @api private
       def data
         data = {
+          item: @record,
           event: @record.paper_trail_event || "create",
           whodunnit: PaperTrail.request.whodunnit
         }

--- a/lib/paper_trail/events/update.rb
+++ b/lib/paper_trail/events/update.rb
@@ -25,6 +25,7 @@ module PaperTrail
       # @api private
       def data
         data = {
+          item: @record,
           event: @record.paper_trail_event || "update",
           whodunnit: PaperTrail.request.whodunnit
         }

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -35,6 +35,7 @@ has been destroyed.
   s.add_development_dependency "byebug", "~> 10.0"
   s.add_development_dependency "ffaker", "~> 2.8"
   s.add_development_dependency "generator_spec", "~> 0.9.4"
+  s.add_development_dependency "memory_profiler", "~> 0.9.12"
   s.add_development_dependency "mysql2", "~> 0.5.2"
   s.add_development_dependency "paper_trail-association_tracking", "~> 2.0.0"
   s.add_development_dependency "pg", "~> 1.0"

--- a/spec/support/performance_helpers.rb
+++ b/spec/support/performance_helpers.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "memory_profiler"
+
+RSpec::Matchers.define :allocate_less_than do |expected|
+  supports_block_expectations
+
+  chain :bytes do
+    @scale = :bs
+  end
+
+  chain :kilobytes do
+    @scale = :kbs
+  end
+
+  chain :and_print_report do
+    @report = true
+  end
+
+  match do |actual|
+    @scale ||= :bs
+
+    benchmark = MemoryProfiler.report(ignore_files: /rspec/) { actual.call }
+
+    if @report
+      benchmark.pretty_print(detailed_report: true, scale_bytes: true)
+    end
+
+    @allocated = benchmark.total_allocated_memsize
+    @allocated /= 1024 if @scale == :kbs
+    @allocated <= expected
+  end
+
+  failure_message do
+    "expected that example will allocate less than #{expected}#{@scale},"\
+    " but allocated #{@allocated}#{@scale}"
+  end
+end


### PR DESCRIPTION
It prevents the repeating hashes creation during the calculation of `object` and `object_changes`.

The real-life case, discovered with a help of `memory_profiler` gem:
1. It saves `~35Mb` per bulk of 100 typical objects like `User`;
2. It saves `~875Mb` per Sidekiq process full of bulk jobs like P1, under default concurrency 25.

As a part of RAM optimization we do:
*  memoization of repeatedly called `PaperTrail::Events::Base` methods;
* cache the AR `changed_attributes` for AR < 5.1;
* prefer to build the Version objects by pure `Class.new` instead of `association.build`.

The record's association cache will be invalidated on the way by `association.reset`, so no any explicit `versions.reload` calls are needed now.

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
