### PR TITLE
Skip excess cloning of JSONized `object_changes`

### DIFF
--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -238,9 +238,14 @@ module PaperTrail
       # serialization here, using `PaperTrail.serializer`.
       #
       # @api private
+      # @param changes HashWithIndifferentAccess
       def recordable_object_changes(changes)
         if PaperTrail.config.object_changes_adapter&.respond_to?(:diff)
-          changes = PaperTrail.config.object_changes_adapter.diff(changes)
+          # We'd like to avoid the `to_hash` here, because it increases memory
+          # usage, but that would be a breaking change because
+          # `object_changes_adapter` expects a plain `Hash`, not a
+          # `HashWithIndifferentAccess`.
+          changes = PaperTrail.config.object_changes_adapter.diff(changes.to_hash)
         end
 
         if @record.class.paper_trail.version_class.object_changes_col_is_json?
@@ -285,6 +290,9 @@ module PaperTrail
         AttributeSerializers::ObjectChangesAttribute.
           new(@record.class).
           serialize(changes)
+
+        # We'd like to convert this `HashWithIndifferentAccess` to a plain
+        # `Hash`, but we don't, to save memory.
         changes
       end
     end

--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -285,7 +285,7 @@ module PaperTrail
         AttributeSerializers::ObjectChangesAttribute.
           new(@record.class).
           serialize(changes)
-        changes.to_hash
+        changes
       end
     end
   end

--- a/lib/paper_trail/serializers/yaml.rb
+++ b/lib/paper_trail/serializers/yaml.rb
@@ -13,6 +13,7 @@ module PaperTrail
       end
 
       def dump(object)
+        object = object.to_hash if object.is_a?(HashWithIndifferentAccess)
         ::YAML.dump object
       end
 

--- a/lib/paper_trail/serializers/yaml.rb
+++ b/lib/paper_trail/serializers/yaml.rb
@@ -12,6 +12,10 @@ module PaperTrail
         ::YAML.load string
       end
 
+      # @param object (Hash | HashWithIndifferentAccess) - Coming from
+      # `recordable_object` `object` will be a plain `Hash`. However, due to
+      # recent [memory optimizations](https://git.io/fjeYv), when coming from
+      # `recordable_object_changes`, it will be a `HashWithIndifferentAccess`.
       def dump(object)
         object = object.to_hash if object.is_a?(HashWithIndifferentAccess)
         ::YAML.dump object

--- a/spec/paper_trail/serializers/yaml_spec.rb
+++ b/spec/paper_trail/serializers/yaml_spec.rb
@@ -15,6 +15,7 @@ module PaperTrail
           float: 4.2
         }
       }
+      let(:hash_with_indifferent_access) { HashWithIndifferentAccess.new(hash) }
 
       describe ".load" do
         it "deserializes YAML to Ruby" do
@@ -26,6 +27,8 @@ module PaperTrail
       describe ".dump" do
         it "serializes Ruby to YAML" do
           expect(described_class.dump(hash)).to eq(hash.to_yaml)
+          expect(described_class.dump(hash_with_indifferent_access)).
+            to eq(hash.stringify_keys.to_yaml)
           expect(described_class.dump(array)).to eq(array.to_yaml)
         end
       end


### PR DESCRIPTION
Every `clone`-like operation over the `object_changes` column will allocate the `O(n)` of RAM, where `n` is a kind of complexity of `object` model in general and applied changes in particular. 

Lets skip excess `object_changes.to_hash` call when the `object_changes` is a kind of `json` column.

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
