### PR TITLE
add 'limit' option to has_paper_trail to override global PaperTrail.config.version_limit setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- [#1194](https://github.com/paper-trail-gem/paper_trail/pull/1194) - 
-  Added a 'limit' option to has_paper_trail, allowing models to override the 
+- [#1194](https://github.com/paper-trail-gem/paper_trail/pull/1194) -
+  Added a 'limit' option to has_paper_trail, allowing models to override the
   global `PaperTrail.config.version_limit` setting.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,44 +5,15 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
-Added a 'limit' option to has_paper_trail, allowing models to override the global `PaperTrail.config.version_limit` setting.
-
-Note that in order to use this option, you must have added the 
-optional 'item_subtype' column as indicated in [Section 4.b.1](https://github.com/paper-trail-gem/paper_trail#4b1-the-optional-item_subtype-column).
-
-For example, having set in your initializer:
-```
- PaperTrail.config.version_limit = 10
-```
-
-with these models:
-
-```
-class Widget < ActiveRecord::Base
-  #there will be at most 10 versions of this model 
-  has_paper_trail
-end
-
-class Bicycle < ActiveRecord::Base 
-  #there will be at most 2 versions of this model 
-  has_paper_trail limit: 2
-end
-
-class Unlimited < ActiveRecord::Base 
-  #there will be an infinite number of versions of this model 
-  has_paper_trail limit: nil
-end
-```
-
-
-
 ### Breaking Changes
 
 - None
 
 ### Added
 
-- None
+- [#1194](https://github.com/paper-trail-gem/paper_trail/pull/1194) - 
+  Added a 'limit' option to has_paper_trail, allowing models to override the 
+  global `PaperTrail.config.version_limit` setting.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
+Added a 'limit' option to has_paper_trail, allowing models to override the global `PaperTrail.config.version_limit` setting.
+
+Note that in order to use this option, you must have added the 
+optional 'item_subtype' column as indicated in [Section 4.b.1](https://github.com/paper-trail-gem/paper_trail#4b1-the-optional-item_subtype-column).
+
+For example, having set in your initializer:
+```
+ PaperTrail.config.version_limit = 10
+```
+
+with these models:
+
+```
+class Widget < ActiveRecord::Base
+  #there will be at most 10 versions of this model 
+  has_paper_trail
+end
+
+class Bicycle < ActiveRecord::Base 
+  #there will be at most 2 versions of this model 
+  has_paper_trail limit: 2
+end
+
+class Unlimited < ActiveRecord::Base 
+  #there will be an infinite number of versions of this model 
+  has_paper_trail limit: nil
+end
+```
+
+
+
 ### Breaking Changes
 
 - None

--- a/README.md
+++ b/README.md
@@ -885,6 +885,20 @@ So, if you use PT-AT and STI, the addition of this column is recommended.
 - https://github.com/paper-trail-gem/paper_trail/pull/1143
 - https://github.com/westonganger/paper_trail-association_tracking/pull/5
 
+When the `item_subtype` column is present in the `versions` table, the has_paper_trail 
+directive allows for an additional `limit` argument, which overrides the global 
+`PaperTrail.config.version_limit` variable.
+
+example:  
+```ruby
+# Limit: 3 versions per record (2 most recent, plus a `create` event)
+# This overrides what is set in `PaperTrail.config.version_limit`
+class Widget < ActiveRecord::Base 
+  has_paper_trail limit: 2
+end
+```
+
+
 ### 4.c. Storing Metadata
 
 You can add your own custom columns to your `versions` table. Values can be

--- a/README.md
+++ b/README.md
@@ -591,10 +591,10 @@ PaperTrail.config.version_limit = 10
 has_paper_trail
 
 # At most 3 versions (2 updates, 1 create). Overrides global version_limit.
-has_paper_trail limit: 2 
+has_paper_trail limit: 2
 
-# Infinite versions 
-has_paper_trail limit: nil 
+# Infinite versions
+has_paper_trail limit: nil
 ```
 
 To use a per-model limit, your `versions` table must have an

--- a/README.md
+++ b/README.md
@@ -577,6 +577,30 @@ PaperTrail.config.version_limit = 3
 PaperTrail.config.version_limit = nil
 ```
 
+#### 2.e.1 Per-model limit
+
+Models can override the global `PaperTrail.config.version_limit` setting.
+
+Example:
+
+```
+# initializer
+PaperTrail.config.version_limit = 10
+
+# At most 10 versions
+has_paper_trail
+
+# At most 3 versions (2 updates, 1 create). Overrides global version_limit.
+has_paper_trail limit: 2 
+
+# Infinite versions 
+has_paper_trail limit: nil 
+```
+
+To use a per-model limit, your `versions` table must have an
+`item_subtype` column. See [Section
+4.b.1](https://github.com/paper-trail-gem/paper_trail#4b1-the-optional-item_subtype-column).
+
 ## 3. Working With Versions
 
 ### 3.a. Reverting And Undeleting A Model
@@ -884,20 +908,6 @@ So, if you use PT-AT and STI, the addition of this column is recommended.
 - https://github.com/paper-trail-gem/paper_trail/issues/594
 - https://github.com/paper-trail-gem/paper_trail/pull/1143
 - https://github.com/westonganger/paper_trail-association_tracking/pull/5
-
-When the `item_subtype` column is present in the `versions` table, the has_paper_trail 
-directive allows for an additional `limit` argument, which overrides the global 
-`PaperTrail.config.version_limit` variable.
-
-example:  
-```ruby
-# Limit: 3 versions per record (2 most recent, plus a `create` event)
-# This overrides what is set in `PaperTrail.config.version_limit`
-class Widget < ActiveRecord::Base 
-  has_paper_trail limit: 2
-end
-```
-
 
 ### 4.c. Storing Metadata
 

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -120,6 +120,7 @@ module PaperTrail
       # this method returns the constant `Animal`. You can see this particular
       # example in action in `spec/models/animal_spec.rb`.
       #
+      # TODO: Duplication: similar `constantize` in VersionConcern#version_limit
       def version_reification_class(version, attrs)
         inheritance_column_name = version.item_type.constantize.inheritance_column
         inher_col_value = attrs[inheritance_column_name]

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -349,7 +349,7 @@ module PaperTrail
     #
     # TODO: Duplication: similar `constantize` in Reifier#version_reification_class
     def version_limit
-      if PaperTrail::Version.column_names.include?("item_subtype")
+      if self.class.item_subtype_column_present?
         klass = (item_subtype || item_type).constantize
         if klass&.paper_trail_options&.key?(:limit)
           return klass.paper_trail_options[:limit]

--- a/spec/dummy_app/app/models/limited_bicycle.rb
+++ b/spec/dummy_app/app/models/limited_bicycle.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class LimitedBicycle < Vehicle
+  has_paper_trail limit: 3
+end

--- a/spec/dummy_app/app/models/unlimited_bicycle.rb
+++ b/spec/dummy_app/app/models/unlimited_bicycle.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class UnlimitedBicycle < Vehicle
+  has_paper_trail limit: nil
+end

--- a/spec/paper_trail/config_spec.rb
+++ b/spec/paper_trail/config_spec.rb
@@ -42,6 +42,50 @@ module PaperTrail
         expect(widget.versions.first.event).to(eq("create"))
         expect(widget.versions.size).to(eq(3))
       end
+
+      it "overrides the general limits to 4 (3 plus the created at event)" do
+        PaperTrail.config.version_limit = 100
+        bike = LimitedBicycle.create!(name: "Limited Bike") # has_paper_trail limit: 3
+        10.times { bike.update_attribute(:name, FFaker::Lorem.word) }
+        expect(bike.versions.first.event).to(eq("create"))
+        expect(bike.versions.size).to(eq(4))
+      end
+
+      it "overrides the general limits with unlimited versions for model" do
+        PaperTrail.config.version_limit = 10
+        bike = UnlimitedBicycle.create!(name: "Unlimited Bike") # has_paper_trail limit: nil
+        100.times.each do |i| bike.update_attribute(:name, "#{i} #{FFaker::Lorem.word}") end
+        expect(bike.versions.first.event).to(eq("create"))
+        expect(bike.versions.size).to(eq(101))
+      end
+
+      it "is not enabled on non-papertrail STI base classes, but enabled on subclasses" do
+        PaperTrail.config.version_limit = 10
+        vehicle = Vehicle.create!(name: "A Vehicle", type: "Vehicle")
+        assert !vehicle.respond_to?(:versions)
+
+        limited_bike = LimitedBicycle.create!(name: "Limited")
+        assert limited_bike.respond_to?(:versions)
+        limited_bike.name = "A new name"
+        limited_bike.save
+        assert_equal 2, limited_bike.versions.length
+      end
+
+      it "uses global version_limit and warns without item_subtype" do
+        PaperTrail.config.version_limit = 30
+        names = PaperTrail::Version.column_names - ["item_subtype"]
+        allow(PaperTrail::Version).to receive(:column_names).and_return(names)
+
+        # spy = spy("logger")
+        # allow(::Rails).to receive(:logger).and_return(spy)
+        # expect(spy).to have_received(:warn).with(/.*paper_trail WARNING.*/m)
+
+        bike = LimitedBicycle.create!(name: "My Bike") # has_paper_trail limit: 3
+        100.times do |i|
+          bike.update(name: "Name #{i}")
+        end
+        assert_equal 31, bike.versions.length
+      end
     end
   end
 end

--- a/spec/paper_trail/config_spec.rb
+++ b/spec/paper_trail/config_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "securerandom"
 require "spec_helper"
 
 module PaperTrail
@@ -38,7 +39,7 @@ module PaperTrail
       it "limits the number of versions to 3 (2 plus the created at event)" do
         PaperTrail.config.version_limit = 2
         widget = Widget.create!(name: "Henry")
-        6.times { widget.update_attribute(:name, FFaker::Lorem.word) }
+        6.times { widget.update_attribute(:name, SecureRandom.hex(8)) }
         expect(widget.versions.first.event).to(eq("create"))
         expect(widget.versions.size).to(eq(3))
       end
@@ -46,45 +47,37 @@ module PaperTrail
       it "overrides the general limits to 4 (3 plus the created at event)" do
         PaperTrail.config.version_limit = 100
         bike = LimitedBicycle.create!(name: "Limited Bike") # has_paper_trail limit: 3
-        10.times { bike.update_attribute(:name, FFaker::Lorem.word) }
+        10.times { bike.update_attribute(:name, SecureRandom.hex(8)) }
         expect(bike.versions.first.event).to(eq("create"))
         expect(bike.versions.size).to(eq(4))
       end
 
       it "overrides the general limits with unlimited versions for model" do
-        PaperTrail.config.version_limit = 10
+        PaperTrail.config.version_limit = 3
         bike = UnlimitedBicycle.create!(name: "Unlimited Bike") # has_paper_trail limit: nil
-        100.times.each do |i| bike.update_attribute(:name, "#{i} #{FFaker::Lorem.word}") end
+        6.times { bike.update_attribute(:name, SecureRandom.hex(8)) }
         expect(bike.versions.first.event).to(eq("create"))
-        expect(bike.versions.size).to(eq(101))
+        expect(bike.versions.size).to eq(7)
       end
 
       it "is not enabled on non-papertrail STI base classes, but enabled on subclasses" do
         PaperTrail.config.version_limit = 10
-        vehicle = Vehicle.create!(name: "A Vehicle", type: "Vehicle")
-        assert !vehicle.respond_to?(:versions)
-
+        Vehicle.create!(name: "A Vehicle", type: "Vehicle")
         limited_bike = LimitedBicycle.create!(name: "Limited")
-        assert limited_bike.respond_to?(:versions)
         limited_bike.name = "A new name"
         limited_bike.save
         assert_equal 2, limited_bike.versions.length
       end
 
-      it "uses global version_limit and warns without item_subtype" do
-        PaperTrail.config.version_limit = 30
-        names = PaperTrail::Version.column_names - ["item_subtype"]
-        allow(PaperTrail::Version).to receive(:column_names).and_return(names)
-
-        # spy = spy("logger")
-        # allow(::Rails).to receive(:logger).and_return(spy)
-        # expect(spy).to have_received(:warn).with(/.*paper_trail WARNING.*/m)
-
-        bike = LimitedBicycle.create!(name: "My Bike") # has_paper_trail limit: 3
-        100.times do |i|
-          bike.update(name: "Name #{i}")
+      context "when item_subtype column is absent" do
+        it "uses global version_limit" do
+          PaperTrail.config.version_limit = 6
+          names = PaperTrail::Version.column_names - ["item_subtype"]
+          allow(PaperTrail::Version).to receive(:column_names).and_return(names)
+          bike = LimitedBicycle.create!(name: "My Bike") # has_paper_trail limit: 3
+          10.times { bike.update(name: SecureRandom.hex(8)) }
+          assert_equal 7, bike.versions.length
         end
-        assert_equal 31, bike.versions.length
       end
     end
   end

--- a/spec/paper_trail/version_limit_spec.rb
+++ b/spec/paper_trail/version_limit_spec.rb
@@ -10,12 +10,14 @@ module PaperTrail
 
     it "cleans up old versions with limit specified in model" do
       PaperTrail.config.version_limit = 10
+
+      # LimitedBicycle overrides the global version_limit
       bike = LimitedBicycle.create(name: "Bike") # has_paper_trail limit: 3
 
-      100.times do |i|
+      15.times do |i|
         bike.update(name: "Name #{i}")
       end
-      expect(LimitedBicycle.find(bike.id).versions.count).to be <= 4
+      expect(LimitedBicycle.find(bike.id).versions.count).to eq(4)
       # 4 versions = 3 updates + 1 create.
     end
 

--- a/spec/paper_trail/version_limit_spec.rb
+++ b/spec/paper_trail/version_limit_spec.rb
@@ -8,6 +8,17 @@ module PaperTrail
       PaperTrail.config.version_limit = nil
     end
 
+    it "cleans up old versions with limit specified in model" do
+      PaperTrail.config.version_limit = 10
+      bike = LimitedBicycle.create(name: "Bike") # has_paper_trail limit: 3
+
+      100.times do |i|
+        bike.update(name: "Name #{i}")
+      end
+      expect(LimitedBicycle.find(bike.id).versions.count).to be <= 4
+      # 4 versions = 3 updates + 1 create.
+    end
+
     it "cleans up old versions" do
       PaperTrail.config.version_limit = 10
       widget = Widget.create


### PR DESCRIPTION
…PaperTrail.config.version_limit value on a per-model basis.

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
