### PR TITLE
Fixes item_id For Versions Migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1196](https://github.com/paper-trail-gem/paper_trail/pull/1196) -
+  Added 'limit: 8' as an additional parameter to the item_id field
+  for the versions table. Bigint is the current default datatype for
+  the id column of Rails tables. This change allows id values to be
+  properly stored when they would exceed the range of a 4 byte integer
+  datatype.
 
 ## 10.2.1 (2019-03-14)
 

--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -11,7 +11,7 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :versions<%= versions_table_options %> do |t|
       t.string   :item_type<%= item_type_options %>
-      t.integer  :item_id,   null: false
+      t.integer  :item_id,   null: false, limit: 8
       t.string   :event,     null: false
       t.string   :whodunnit
       t.text     :object, limit: TEXT_BYTES


### PR DESCRIPTION
Added 'limit: 8' as an additional parameter to the item_id field for the versions table. Bigint is the current default datatype for the id column of Rails tables and a reasonable choice for non Rails projects. This change allows id values to be properly stored when they would exceed the range of a 4 byte integer datatype.

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/