### PR TITLE
update migration to jsonb with object_changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1212,14 +1212,27 @@ loop over every record and parse it in Ruby, then write to a temporary column:
 
 ```ruby
 add_column :versions, :new_object, :jsonb # or :json
+# add_column :versions, :new_object_changes, :jsonb # or :json
 
-PaperTrail::Version.reset_column_information
+# PaperTrail::Version.reset_column_information # needed for rails < 6
+
 PaperTrail::Version.find_each do |version|
-  version.update_column :new_object, YAML.load(version.object) if version.object
+  if version.object
+    version.update_column(:new_object, YAML.load(version.object))
+  end
+
+  # if version.object_changes
+  #   version.update_column(
+  #     :new_object_changes,
+  #     YAML.load(version.object_changes)
+  #   )
+  # end
 end
 
 remove_column :versions, :object
+# remove_column :versions, :object_changes
 rename_column :versions, :new_object, :object
+# rename_column :versions, :new_object_changes, :object_changes
 ```
 
 This technique can be very slow if you have a lot of data. Though slow, it is


### PR DESCRIPTION
tried it on my rails 6.0.0beta3 project and worked fine, trying to make it future-proof by commenting out the `reset` which as far as I remember isn't needed on rails 5 either.

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- Added tests. (tested it on my project, could add a test for it if needed)
- Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes. (no need)
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/