### PR TITLE
Faster way to update from YAML to JSON.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,11 +1216,9 @@ add_column :versions, :new_object, :jsonb # or :json
 
 # PaperTrail::Version.reset_column_information # needed for rails < 6
 
-PaperTrail::Version.find_each do |version|
-  if version.object
-    version.update_column(:new_object, YAML.load(version.object))
-  end
-
+PaperTrail::Version.where.not(object: nil).find_each do |version|
+  version.update_column(:new_object, YAML.load(version.object))
+  
   # if version.object_changes
   #   version.update_column(
   #     :new_object_changes,


### PR DESCRIPTION
Rather than fetch every version and then check if it has an object, select only those with objects. For my database this cuts it from 13 million fetches to 1.7 million.