### PR TITLE
Update README: Add missing option to generator documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,7 +1065,8 @@ Usage:
   rails generate paper_trail:install [options]
 
 Options:
-  [--with-changes], [--no-with-changes]            # Store changeset (diff) with each version
+  [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)
+  [--with-changes], [--no-with-changes]      # Store changeset (diff) with each version
 
 Runtime options:
   -f, [--force]                    # Overwrite files that already exist


### PR DESCRIPTION
I ran the `--help` command on my development machine and noticed the command outputs a bit more than what's in the README. This PR updates the README to reflect this new feature.

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- N/A Added tests.
- N/A Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
