### PR TITLE
Remove upper bound of Active Record

### DIFF
--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -27,8 +27,9 @@ has been destroyed.
   s.required_rubygems_version = ">= 1.3.6"
   s.required_ruby_version = ">= 2.3.0"
 
-  # Rails does not follow semver, makes breaking changes in minor versions.
-  s.add_dependency "activerecord", [">= 4.2", "< 6.1"]
+  # Rails does not follow semver, makes breaking changes in minor versions, so check of the CI pipeline
+  # to see if the version of Rails you are using has tests passing.
+  s.add_dependency "activerecord", ">= 4.2"
   s.add_dependency "request_store", "~> 1.1"
 
   s.add_development_dependency "appraisal", "~> 2.2"


### PR DESCRIPTION
The way it is was didn't allow people to try paper trail with rails master to check if it work or not. Removing the upper bound doesn't assert that the gem works with all versions, it just allow people to try themselves and even open PRs fixing what is broken.