### PR TITLE
Support custom id key per model

### DIFF
--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -46,6 +46,11 @@ module PaperTrail
 
       private
 
+      def record_id
+        id_key = @record.paper_trail_options[:id_key]
+        id_key.present? ? @record[id_key] : @record.id
+      end
+
       # Rails 5.1 changed the API of `ActiveRecord::Dirty`. See
       # https://github.com/paper-trail-gem/paper_trail/pull/899
       #

--- a/lib/paper_trail/events/create.rb
+++ b/lib/paper_trail/events/create.rb
@@ -14,6 +14,7 @@ module PaperTrail
       def data
         data = {
           item: @record,
+          item_id: record_id,
           event: @record.paper_trail_event || "create",
           whodunnit: PaperTrail.request.whodunnit
         }

--- a/lib/paper_trail/events/destroy.rb
+++ b/lib/paper_trail/events/destroy.rb
@@ -13,7 +13,7 @@ module PaperTrail
       # @api private
       def data
         data = {
-          item_id: @record.id,
+          item_id: record_id,
           item_type: @record.class.base_class.name,
           event: @record.paper_trail_event || "destroy",
           whodunnit: PaperTrail.request.whodunnit

--- a/lib/paper_trail/events/update.rb
+++ b/lib/paper_trail/events/update.rb
@@ -26,6 +26,7 @@ module PaperTrail
       def data
         data = {
           item: @record,
+          item_id: record_id,
           event: @record.paper_trail_event || "update",
           whodunnit: PaperTrail.request.whodunnit
         }

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -187,6 +187,7 @@ module PaperTrail
         @model_class.versions_association_name,
         scope,
         class_name: @model_class.version_class_name,
+        primary_key: options[:id_key] || @model_class.primary_key,
         as: :item,
         **options[:versions].except(:name, :scope)
       )

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -46,7 +46,7 @@ module PaperTrail
     #  "live" item, we return nil.  Perhaps we should return self instead?
     def next_version
       subsequent_version = source_version.next
-      subsequent_version ? subsequent_version.reify : @record.class.find(@record.id)
+      subsequent_version ? subsequent_version.reify : @record.class.find(record_id)
     rescue StandardError # TODO: Rescue something more specific
       nil
     end
@@ -247,6 +247,11 @@ module PaperTrail
 
     private
 
+    def record_id
+      id_key = @record.paper_trail_options[:id_key]
+      id_key.present? ? @record[id_key] : @record.id
+    end
+
     # @api private
     def assign_and_reset_version_association(version)
       @record.send("#{@record.class.version_association_name}=", version)
@@ -285,7 +290,7 @@ module PaperTrail
     def log_version_errors(version, action)
       version.logger&.warn(
         "Unable to create version for #{action} of #{@record.class.name}" \
-          "##{@record.id}: " + version.errors.full_messages.join(", ")
+          "##{record_id}: " + version.errors.full_messages.join(", ")
       )
     end
 

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -59,9 +59,10 @@ module PaperTrail
           end
         else
           klass = version_reification_class(version, attrs)
+          id_key = klass.paper_trail_options[:id_key] || klass.primary_key
           # The `dup` option always returns a new object, otherwise we should
           # attempt to look for the item outside of default scope(s).
-          find_cond = { klass.primary_key => version.item_id }
+          find_cond = { id_key => version.item_id }
           if options[:dup] || (item_found = klass.unscoped.where(find_cond).first).nil?
             model = klass.new
           elsif options[:unversioned_attributes] == :nil

--- a/spec/dummy_app/app/models/custom_id_key_record.rb
+++ b/spec/dummy_app/app/models/custom_id_key_record.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+class CustomIdKeyRecord < ActiveRecord::Base
+  has_paper_trail id_key: :uuid, versions: { class_name: "CustomPrimaryKeyRecordVersion" }
+
+  before_create do
+    self.uuid ||= SecureRandom.uuid
+  end
+end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -329,6 +329,12 @@ class SetUpTestTables < (
     add_index :bar_habtms_foo_habtms, [:foo_habtm_id]
     add_index :bar_habtms_foo_habtms, [:bar_habtm_id]
 
+    create_table :custom_id_key_records, force: true do |t|
+      t.column :uuid, :string
+      t.string :name
+      t.timestamps null: true, limit: 6
+    end
+
     # custom_primary_key_records use a uuid column (string)
     create_table :custom_primary_key_records, id: false, force: true do |t|
       t.column :uuid, :string, primary_key: true

--- a/spec/models/custom_id_key_record_spec.rb
+++ b/spec/models/custom_id_key_record_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CustomIdKeyRecord, type: :model do
+  it { is_expected.to be_versioned }
+
+  describe "#versions" do
+    it "returns instances of CustomPrimaryKeyRecordVersion", versioning: true do
+      custom_id_key_record = described_class.create!
+      custom_id_key_record.update!(name: "bob")
+      version = custom_id_key_record.versions.last
+      expect(version).to be_a(CustomPrimaryKeyRecordVersion)
+      version_from_db = CustomPrimaryKeyRecordVersion.last
+      expect(version_from_db.item_id).to eq(custom_id_key_record.uuid)
+      expect(version_from_db.reify).to be_a(CustomIdKeyRecord)
+      custom_id_key_record.destroy
+      expect(CustomPrimaryKeyRecordVersion.last.reify).to be_a(CustomIdKeyRecord)
+    end
+  end
+end


### PR DESCRIPTION
## Motivation / Use case
In a project I'm currently working on we use `Heroku Connect` to sync tables from Salesforce into our Postgres DB. `Heroku Connect` will sync the existing rows in Salesforce and the primary key `id` from Rails will be automatically generated. The problem is that we can't count on that `id` because Heroku Connect could reload or resync the tables in some situations. So the `id` isn't actually identifying the row and what is actually identifying them is the column `sfid` which is handled by Salesforce (a 18 character length string). So we need to use that column as the `item_id` in PaperTrail. I thought on changing the `primary_key` of that models but then I realised it would break other things. For that reason I'm adding a per-model configuration where you can change the id to use for `item_id`.

## Notes
I feel like the tests could not be enough, but I was following the testing for "custom primary key" model. I'm open to add more tests if you can suggest me which ones could be worth it.
I'll also make the changes to the CHANGELOG if you approve moving forward with this feature.