### PR TITLE
Introduce API for the model primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- [#1228](https://github.com/paper-trail-gem/paper_trail/pull/1228)
+  Centralizes in a single method the id of the class to be used for the versions table.
+  By default it uses the class `primary_key` but it can be overriden to take another value.
+  The `paper_trail-configurable_item_id` gem is created to provide a way to customize as an option
+  of the `has_paper_trail` method.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ has been destroyed.
   - [6.a. Custom Version Classes](#6a-custom-version-classes)
   - [6.b. Custom Serializer](#6b-custom-serializer)
   - [6.c. Custom Object Changes](#6c-custom-object-changes)
+  - [6.d. Excluding the Object Column](#6d-excluding-the-object-column)
+  - [6.e. Custom Primary Key for the versions Association](#6e-custom-primary-key-for-the-versions-association)
 - [7. Testing](#7-testing)
   - [7.a. Minitest](#7a-minitest)
   - [7.b. RSpec](#7b-rspec)
@@ -1339,6 +1341,13 @@ For an example of a complete and useful adapter, see
 The `object` column ends up storing a lot of duplicate data if you have models that have many columns,
 and that are updated many times. You can save ~50% of storage space by removing the column from the
 versions table. It's important to note that this will disable `reify` and `where_object`.
+
+
+### 6.e. Custom Primary Key for the versions Association
+
+The versions table by default uses the class `primary_key` for the association. If you want another column
+to be used for the association, you can override the `primary_key_for_has_many_versions` method of the
+`PaperTrail::ModelConfig` class or use the `paper_trail-configurable_item_id` gem.
 
 ## 7. Testing
 

--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -275,6 +275,20 @@ module PaperTrail
         end
       end
 
+      # Returns the record id for the versions table
+      #
+      # @api private
+      def record_id
+        @record[@record.class.paper_trail.primary_key_for_has_many_versions]
+      end
+
+      # Returns the record type for the versions table
+      #
+      # @api private
+      def record_type
+        @record.class.base_class.name
+      end
+
       # Returns a boolean indicating whether to store serialized version diffs
       # in the `object_changes` column of the version record.
       #

--- a/lib/paper_trail/events/create.rb
+++ b/lib/paper_trail/events/create.rb
@@ -13,7 +13,8 @@ module PaperTrail
       # @api private
       def data
         data = {
-          item: @record,
+          item_id: record_id,
+          item_type: record_type,
           event: @record.paper_trail_event || "create",
           whodunnit: PaperTrail.request.whodunnit
         }

--- a/lib/paper_trail/events/destroy.rb
+++ b/lib/paper_trail/events/destroy.rb
@@ -13,8 +13,8 @@ module PaperTrail
       # @api private
       def data
         data = {
-          item_id: @record.id,
-          item_type: @record.class.base_class.name,
+          item_id: record_id,
+          item_type: record_type,
           event: @record.paper_trail_event || "destroy",
           whodunnit: PaperTrail.request.whodunnit
         }

--- a/lib/paper_trail/events/update.rb
+++ b/lib/paper_trail/events/update.rb
@@ -25,7 +25,8 @@ module PaperTrail
       # @api private
       def data
         data = {
-          item: @record,
+          item_id: record_id,
+          item_type: record_type,
           event: @record.paper_trail_event || "update",
           whodunnit: PaperTrail.request.whodunnit
         }

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -122,6 +122,16 @@ module PaperTrail
       setup_callbacks_from_options options[:on]
     end
 
+    # Single source of truth of the primary_key used for the versions association
+    # Can be overriden by a gem to allow custom primary keys for the has_many
+    # versions association
+    # https://github.com/paper-trail-gem/paper_trail/pull/1226
+    # https://github.com/paper-trail-gem/paper_trail/pull/1228
+    # @api public
+    def primary_key_for_has_many_versions
+      @model_class.primary_key
+    end
+
     def version_class
       @_version_class ||= @model_class.version_class_name.constantize
     end
@@ -187,6 +197,7 @@ module PaperTrail
         @model_class.versions_association_name,
         scope,
         class_name: @model_class.version_class_name,
+        primary_key: primary_key_for_has_many_versions,
         as: :item,
         **options[:versions].except(:name, :scope)
       )

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -46,7 +46,7 @@ module PaperTrail
     #  "live" item, we return nil.  Perhaps we should return self instead?
     def next_version
       subsequent_version = source_version.next
-      subsequent_version ? subsequent_version.reify : @record.class.find(@record.id)
+      subsequent_version ? subsequent_version.reify : @record.class.find(record_id)
     rescue StandardError # TODO: Rescue something more specific
       nil
     end
@@ -285,8 +285,13 @@ module PaperTrail
     def log_version_errors(version, action)
       version.logger&.warn(
         "Unable to create version for #{action} of #{@record.class.name}" \
-          "##{@record.id}: " + version.errors.full_messages.join(", ")
+          "##{record_id}: " + version.errors.full_messages.join(", ")
       )
+    end
+
+    # @api private
+    def record_id
+      @record[@record.class.paper_trail.primary_key_for_has_many_versions]
     end
 
     def version

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -61,8 +61,7 @@ module PaperTrail
           klass = version_reification_class(version, attrs)
           # The `dup` option always returns a new object, otherwise we should
           # attempt to look for the item outside of default scope(s).
-          find_cond = { klass.primary_key => version.item_id }
-          if options[:dup] || (item_found = klass.unscoped.where(find_cond).first).nil?
+          if options[:dup] || (item_found = find_item(klass, version)).nil?
             model = klass.new
           elsif options[:unversioned_attributes] == :nil
             model = item_found
@@ -70,6 +69,13 @@ module PaperTrail
           end
         end
         model
+      end
+
+      # Given a class and a version finds the item by id
+      # @api private
+      def find_item(klass, version)
+        find_cond = { klass.paper_trail.primary_key_for_has_many_versions => version.item_id }
+        klass.unscoped.where(find_cond).first
       end
 
       # Look for attributes that exist in `model` and not in this version.

--- a/spec/dummy_app/app/models/custom_id_key_record.rb
+++ b/spec/dummy_app/app/models/custom_id_key_record.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+module PaperTrailCustomId
+  module ModelConfig
+    def primary_key_for_has_many_versions
+      instance_variable_get(:@model_class).paper_trail_options[:id_key] ||
+        super
+    end
+  end
+end
+
+module PaperTrail
+  class ModelConfig
+    prepend ::PaperTrailCustomId::ModelConfig
+  end
+end
+
+class CustomIdKeyRecord < ActiveRecord::Base
+  has_paper_trail id_key: :uuid, versions: { class_name: "CustomPrimaryKeyRecordVersion" }
+
+  before_create do
+    self.uuid ||= SecureRandom.uuid
+  end
+end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -329,6 +329,13 @@ class SetUpTestTables < (
     add_index :bar_habtms_foo_habtms, [:foo_habtm_id]
     add_index :bar_habtms_foo_habtms, [:bar_habtm_id]
 
+    # custom_id_key_records have id and uuid
+    create_table :custom_id_key_records, force: true do |t|
+      t.column :uuid, :string
+      t.string :name
+      t.timestamps null: true, limit: 6
+    end
+
     # custom_primary_key_records use a uuid column (string)
     create_table :custom_primary_key_records, id: false, force: true do |t|
       t.column :uuid, :string, primary_key: true

--- a/spec/models/custom_id_key_record_spec.rb
+++ b/spec/models/custom_id_key_record_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe CustomIdKeyRecord, type: :model do
+  it { is_expected.to be_versioned }
+
+  describe "#versions" do
+    it "returns instances of CustomPrimaryKeyRecordVersion", versioning: true do
+      custom_id_key_record = described_class.create!
+      custom_id_key_record.update!(name: "bob")
+      version = custom_id_key_record.versions.last
+      expect(version).to be_a(CustomPrimaryKeyRecordVersion)
+      version_from_db = CustomPrimaryKeyRecordVersion.last
+      expect(version_from_db.item_id).to eq(custom_id_key_record.uuid)
+      expect(version_from_db.reify).to be_a(CustomIdKeyRecord)
+      custom_id_key_record.destroy
+      expect(CustomPrimaryKeyRecordVersion.last.reify).to be_a(CustomIdKeyRecord)
+    end
+  end
+end

--- a/spec/paper_trail/events/create_spec.rb
+++ b/spec/paper_trail/events/create_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module PaperTrail
+  module Events
+    ::RSpec.describe Create do
+      describe "#data", versioning: true do
+        it "includes correct item_subtype" do
+          carter = Family::CelebrityFamily.new(
+            name: "Carter",
+            path_to_stardom: "Mexican radio"
+          )
+          data = PaperTrail::Events::Create.new(carter, nil).data
+          expect(data[:item_type]).to eq("Family::Family")
+          expect(data[:item_subtype]).to eq("Family::CelebrityFamily")
+        end
+      end
+    end
+  end
+end

--- a/spec/paper_trail/events/update_spec.rb
+++ b/spec/paper_trail/events/update_spec.rb
@@ -6,6 +6,17 @@ module PaperTrail
   module Events
     ::RSpec.describe Update do
       describe "#data", versioning: true do
+        it "includes correct item_subtype" do
+          carter = Family::CelebrityFamily.create(
+            name: "Carter",
+            path_to_stardom: "Mexican radio"
+          )
+          carter.path_to_stardom = "Johnny"
+          data = PaperTrail::Events::Update.new(carter, false, false, nil).data
+          expect(data[:item_type]).to eq("Family::Family")
+          expect(data[:item_subtype]).to eq("Family::CelebrityFamily")
+        end
+
         context "is_touch false" do
           it "object_changes is present" do
             carter = Family::CelebrityFamily.create(


### PR DESCRIPTION
Relates to https://github.com/paper-trail-gem/paper_trail/pull/1226

This PR centralizes in one method the id that should be used for the `item_id`. It can be overridden by another gem to extend PT with the possibility to have configurable items ids.