### PR TITLE
Remove duplicate gem dependencies

### DIFF
--- a/gemfiles/ar_5.1.gemfile
+++ b/gemfiles/ar_5.1.gemfile
@@ -4,8 +4,5 @@ source "https://rubygems.org"
 
 gem "activerecord", [">= 5.1.6.2", "< 5.2"]
 gem "rails-controller-testing", "~> 1.0.2"
-gem "mysql2", "~> 0.5.2"
-gem "pg", "~> 1.1"
-gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/ar_5.2.gemfile
+++ b/gemfiles/ar_5.2.gemfile
@@ -4,8 +4,5 @@ source "https://rubygems.org"
 
 gem "activerecord", [">= 5.2.2.1", "< 5.3"]
 gem "rails-controller-testing", "~> 1.0.2"
-gem "mysql2", "~> 0.5.2"
-gem "pg", "~> 1.1"
-gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/ar_6.0.gemfile
+++ b/gemfiles/ar_6.0.gemfile
@@ -4,8 +4,5 @@ source "https://rubygems.org"
 
 gem "activerecord", ["6.0.0"]
 gem "rails-controller-testing", "~> 1.0.3"
-gem "mysql2", "~> 0.5.2"
-gem "pg", "~> 1.1"
-gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"


### PR DESCRIPTION
Bundler was printing warnings because some gems where declared twice, I
believe this is because `appraisal generate` wasn't run when these were
moved to the `.gemspec` file.

For some reason I was unable to move `rails-controller-testing` to the `.gemspec` file.

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
