### PR TITLE
Update README.md to remove old documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,9 +748,6 @@ widget.versions.last.changeset
 # {}
 ```
 
-The `object_changes` are only stored for creation and updates, not when an
-object is destroyed.
-
 Please be aware that PaperTrail doesn't use diffs internally.  When I designed
 PaperTrail I wanted simplicity and robustness so I decided to make each version
 of an object self-contained.  A version stores all of its object's data, not a


### PR DESCRIPTION
Removing "The object_changes are only stored for creation and updates, not when an object is destroyed." per #1236.

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
