### PR TITLE
Convert `item_id` field to bigint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
+- [#1242](https://github.com/paper-trail-gem/paper_trail/issues/1242) -
+  Generator make wrong migration for Oracle database
+
 - [#1238](https://github.com/paper-trail-gem/paper_trail/pull/1238) -
   Query optimization in `reify`
 
@@ -46,9 +49,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Dependencies
 
-- [#1213](https://github.com/paper-trail-gem/paper_trail/pull/1213) - Allow 
+- [#1213](https://github.com/paper-trail-gem/paper_trail/pull/1213) - Allow
   contributors to install incompatible versions of ActiveRecord.
-  See discussion in paper_trail/compatibility.rb 
+  See discussion in paper_trail/compatibility.rb
 
 ## 10.3.0 (2019-04-09)
 

--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -11,7 +11,7 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :versions<%= versions_table_options %> do |t|
       t.string   :item_type<%= item_type_options %>
-      t.integer  :item_id,   null: false, limit: 8
+      t.bigint   :item_id,   null: false
       t.string   :event,     null: false
       t.string   :whodunnit
       t.text     :object, limit: TEXT_BYTES

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -73,7 +73,7 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
 
     create_table :versions, versions_table_options do |t|
       t.string   :item_type, **item_type_options(null: false)
-      t.integer  :item_id, null: false
+      t.bigint   :item_id, null: false
       t.string   :item_subtype, **item_type_options(null: true)
       t.string   :event, null: false
       t.string   :whodunnit


### PR DESCRIPTION
Converting `item_id` field to bigint when generate the `versions` table.

When using paper_trail with PostgreSQL, MySQL and SQLite this patch will not change any field settings, but if using OracleDB it will create a `NUMBER(19)` field instead of `NUMBER(8).

* This PR are related to issue #1242 