### PR TITLE
CI: Drop mention of removed directive sudo: false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,7 @@ env:
     - DB=postgres
     - DB=sqlite
 
-# We want to use `sudo: false` because the container infrastructure is supposed
-# to be faster, but Travis is having issues with containers lately ..
-#
-# > No output has been received in the last 10m0s
-#
-# .. and they recommend we use the VM infrastructure (`sudo: required`) in
-# the meantime.
+# Travis recommend we use the VM infrastructure (`sudo: required`)
 sudo: required
 
 before_install:


### PR DESCRIPTION
This is an attempt to simplify the comment in the CI configuration.

This PR removes mention of the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

---

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
