### PR TITLE
Change install generator to use new hash syntax

### DIFF
--- a/lib/generators/paper_trail/install/install_generator.rb
+++ b/lib/generators/paper_trail/install/install_generator.rb
@@ -36,9 +36,11 @@ module PaperTrail
     # MySQL 5.6 utf8mb4 limit is 191 chars for keys used in indexes.
     # See https://github.com/paper-trail-gem/paper_trail/issues/651
     def item_type_options
-      opt = { null: false }
-      opt[:limit] = 191 if mysql?
-      ", #{opt}"
+      if mysql?
+        ", { null: false, limit: 191 }"
+      else
+        ", { null: false }"
+      end
     end
 
     def mysql?

--- a/spec/generators/paper_trail/install_generator_spec.rb
+++ b/spec/generators/paper_trail/install_generator_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
           ""
         end
       }.call
+      expected_item_type_options = lambda {
+        if described_class::MYSQL_ADAPTERS.include?(ActiveRecord::Base.connection.class.name)
+          ", { null: false, limit: 191 }"
+        else
+          ", { null: false }"
+        end
+      }.call
       expect(destination_root).to(
         have_structure {
           directory("db") {
@@ -43,6 +50,7 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
                 contains("class CreateVersions < " + expected_parent_class)
                 contains "def change"
                 contains "create_table :versions#{expected_create_table_options}"
+                contains "  t.string   :item_type#{expected_item_type_options}"
               }
             }
           }


### PR DESCRIPTION
The install generator used literal Ruby hashes to build options for the
item_type field.  This change modifies the generator to use string
literal output, which is consistent with the other option building method
in the generator.

Thank you for your contribution!

Check the following boxes:

- [X] Wrote [good commit messages][1].
- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [X] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
