### PR TITLE
fixes a bug where if no database exists, has_paper_trail raises exception when running `rake db:create`

### DIFF
--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -145,9 +145,14 @@ module PaperTrail
     #
     # @api private
     def check_presence_of_item_subtype_column(options)
-      return unless options.key?(:limit)
-      return if version_class.item_subtype_column_present?
-      raise format(E_MODEL_LIMIT_REQUIRES_ITEM_SUBTYPE, @model_class.name)
+      begin
+        return unless options.key?(:limit)
+        return if version_class.item_subtype_column_present?
+        raise format(E_MODEL_LIMIT_REQUIRES_ITEM_SUBTYPE, @model_class.name)
+      rescue ActiveRecord::NoDatabaseError => e
+        ::Rails.logger.warn "Database does not Exist!  - not loading papertrail"
+        return true
+      end
     end
 
     def check_version_class_name(options)

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -148,8 +148,12 @@ module PaperTrail
       return unless options.key?(:limit)
       return if version_class.item_subtype_column_present?
       raise format(E_MODEL_LIMIT_REQUIRES_ITEM_SUBTYPE, @model_class.name)
-    rescue ActiveRecord::NoDatabaseError
-      ::Rails.logger.warn "Database does not Exist! - not loading papertrail"
+    rescue ActiveRecord::NoDatabaseError => e
+      # when there is no database
+      ::Rails.logger.warn e.message
+    rescue ActiveRecord::StatementInvalid => e
+      # when versions table does not exist
+      ::Rails.logger.warn e.message
     end
 
     def check_version_class_name(options)

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -145,14 +145,11 @@ module PaperTrail
     #
     # @api private
     def check_presence_of_item_subtype_column(options)
-      begin
-        return unless options.key?(:limit)
-        return if version_class.item_subtype_column_present?
-        raise format(E_MODEL_LIMIT_REQUIRES_ITEM_SUBTYPE, @model_class.name)
-      rescue ActiveRecord::NoDatabaseError => e
-        ::Rails.logger.warn "Database does not Exist!  - not loading papertrail"
-        return true
-      end
+      return unless options.key?(:limit)
+      return if version_class.item_subtype_column_present?
+      raise format(E_MODEL_LIMIT_REQUIRES_ITEM_SUBTYPE, @model_class.name)
+    rescue ActiveRecord::NoDatabaseError
+      ::Rails.logger.warn "Database does not Exist! - not loading papertrail"
     end
 
     def check_version_class_name(options)

--- a/lib/paper_trail/version_number.rb
+++ b/lib/paper_trail/version_number.rb
@@ -9,7 +9,7 @@ module PaperTrail
   module VERSION
     MAJOR = 11
     MINOR = 0
-    TINY = 0
+    TINY = 1
 
     # Set PRE to nil unless it's a pre-release (beta, rc, etc.)
     PRE = nil

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -59,7 +59,7 @@ has been destroyed.
   # `Appraisals`.
   s.add_development_dependency "mysql2", "~> 0.5"
   s.add_development_dependency "pg", ">= 0.18", "< 2.0"
-  s.add_development_dependency "sqlite3", "~> 1.4"
   s.add_development_dependency "rails"
   s.add_development_dependency "rails-controller-testing", "~> 1.0.1"
+  s.add_development_dependency "sqlite3", "~> 1.4"
 end

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -60,4 +60,6 @@ has been destroyed.
   s.add_development_dependency "mysql2", "~> 0.5"
   s.add_development_dependency "pg", ">= 0.18", "< 2.0"
   s.add_development_dependency "sqlite3", "~> 1.4"
+  s.add_development_dependency "rails"
+  s.add_development_dependency "rails-controller-testing", "~> 1.0.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,8 @@ require File.expand_path("dummy_app/config/environment", __dir__)
 require "rspec/rails"
 require "paper_trail/frameworks/rspec"
 require "ffaker"
+require 'rails-controller-testing'
+Rails::Controller::Testing.install
 
 # Migrate
 require_relative "support/paper_trail_spec_migrator"
@@ -40,4 +42,12 @@ require_relative "support/paper_trail_spec_migrator"
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true
+end
+
+RSpec.configure do |config|
+  [:controller, :view, :request].each do |type|
+    config.include ::Rails::Controller::Testing::TestProcess, :type => type
+    config.include ::Rails::Controller::Testing::TemplateAssertions, :type => type
+    config.include ::Rails::Controller::Testing::Integration, :type => type
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,9 +45,9 @@ RSpec.configure do |config|
 end
 
 RSpec.configure do |config|
-  [:controller, :view, :request].each do |type|
-    config.include ::Rails::Controller::Testing::TestProcess, :type => type
-    config.include ::Rails::Controller::Testing::TemplateAssertions, :type => type
-    config.include ::Rails::Controller::Testing::Integration, :type => type
+  %i[controller view request].each do |type|
+    config.include ::Rails::Controller::Testing::TestProcess, type: type
+    config.include ::Rails::Controller::Testing::TemplateAssertions, type: type
+    config.include ::Rails::Controller::Testing::Integration, type: type
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ require File.expand_path("dummy_app/config/environment", __dir__)
 require "rspec/rails"
 require "paper_trail/frameworks/rspec"
 require "ffaker"
-require 'rails-controller-testing'
+require "rails-controller-testing"
 Rails::Controller::Testing.install
 
 # Migrate


### PR DESCRIPTION
Description of bug this PR fixes:

1) Given a rails app which has the `paper_trail` gem already installed
2) and the versions table has a `item_subtype` column per the requirements to use `:limit` option
3) and an ApplicationRecord model is defined with the `has_paper_trail` `:limit` option set
4) and **where the local development database has yet to be created**

Result: when running `rake db:create`, an `ActiveRecord::NoDatabaseError` is raised

Expected result: development and test databases are created and no exception occurs.

```
# versions table (postgres)
create_table "versions", id: :serial, force: :cascade do |t|
    t.string "item_type", limit: 255, null: false
    t.integer "item_id", null: false
    t.string "event", limit: 255, null: false
    t.string "whodunnit", limit: 255
    t.datetime "created_at"
    t.text "object_changes"
    t.string "item_subtype"
    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
  end
```

```
# example model
class User < ApplicationRecord
  has_paper_trail limit: 10
  ...
end
```

```
# create initial database
> bundle exec rake db:create`
```

```
# log output
ActiveRecord::NoDatabaseError: FATAL:  database "my_project_development" does not exist
...
/Users/ckhall/Projects/paper_trail/lib/paper_trail/version_concern.rb:29:in `item_subtype_column_present?'
/Users/ckhall/Projects/paper_trail/lib/paper_trail/model_config.rb:150:in `check_presence_of_item_subtype_column'
/Users/ckhall/Projects/paper_trail/lib/paper_trail/model_config.rb:120:in `setup'
/Users/ckhall/Projects/paper_trail/lib/paper_trail/has_paper_trail.rb:69:in `has_paper_trail'
/Users/ckhall/Projects/my_project/app/models/user.rb:8:in `<class:User>'
/Users/ckhall/Projects/my_project/app/models/user.rb:4:in `<main>'
...
```

because the database has not been created yet, the call to `column_names` [fails](https://github.com/ckhall/paper_trail/blob/master/lib/paper_trail/version_concern.rb#L28-L30) and raises the `ActiveRecord::NoDatabaseError` exception.

fix:

rescues `ActiveRecord::NoDatabaseError` and returns which allows `rake db:create` to continue.

tests:

so not really sure how to write a spec for thi.  in order to duplicate, the database cannot exist yet.  I attemped to go down the `allow_any_instance_of(ApplicationRecord).to receive(:column_names).and_raise(ActiveRecord::NoDatabaseError)` but that didn't really seem the right way to go here.  Happy for any input here.


re: having to add rails and rails-controller-testing gems, I couldn't get specs to pass without them.

==============================

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
