### PR TITLE
No need to send a public method "Object#extend"

### DIFF
--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -12,7 +12,7 @@ module PaperTrail
   # `.paper_trail` and `#paper_trail`.
   module Model
     def self.included(base)
-      base.send :extend, ClassMethods
+      base.extend ClassMethods
     end
 
     # :nodoc:


### PR DESCRIPTION
`Object#extend` has been defined as a public method since the last century (I don't exactly know when, but it already was a public method even on version 1.0.0).
So we don't need to call it via `send`.

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] ~~Added tests.~~
- [ ] ~~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.~~
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.