### PR TITLE
Correct minor issue in code-sample on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,9 +703,9 @@ it came instead from a previous version -- with `live?`:
 
 ```ruby
 widget = Widget.find 42
-widget.live?                        # true
+widget.paper_trail.live?            # true
 widget = widget.paper_trail.previous_version
-widget.live?                        # false
+widget.paper_trail.live?            # false
 ```
 
 And you can perform `WHERE` queries for object versions based on attributes:


### PR DESCRIPTION
Encountered an error when following one of the code-samples in the README.  Initially thought this may be something that was a change in an upcoming version, but that doesn't appear to be the case.

`model.live?` should be `model.paper_trail.live?`

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests. 🚫 - I suspect this is unnecessary for a readme change
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes. 🚫 does not apply
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
