### PR TITLE
Use RuboCop::Packaging amongst other extensions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require:
+  - rubocop-packaging
   - rubocop-performance
   - rubocop-rspec
 

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -66,6 +66,7 @@ has been destroyed.
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rspec-rails", "~> 4.0"
   s.add_development_dependency "rubocop", "~> 0.89.1"
+  s.add_development_dependency "rubocop-packaging", "~> 0.5.1"
   s.add_development_dependency "rubocop-performance", "~> 1.7.1"
   s.add_development_dependency "rubocop-rspec", "~> 1.42.0"
 

--- a/spec/generators/paper_trail/install_generator_spec.rb
+++ b/spec/generators/paper_trail/install_generator_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 require "generator_spec/test_case"
-require File.expand_path("../../../lib/generators/paper_trail/install/install_generator", __dir__)
+require "generators/paper_trail/install/install_generator"
 
 RSpec.describe PaperTrail::InstallGenerator, type: :generator do
   include GeneratorSpec::TestCase


### PR DESCRIPTION
Hello,

Thanks for your work on this so far! ❤️ 
This PR adds another known extension of RuboCop -- RuboCop::Packaging.
Packaging style guide can be found here: https://packaging.rubystyle.guide/
And the docs can be found here: https://docs.rubocop.org/rubocop-packaging/

Should you have any questions, please let me know!

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>
