### PR TITLE
Expand kwargs passed to "save_with_version" with double splat operator - Rails 6.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- Expand kwargs passed to `save_with_version` using double splat operator - Rails 6.1 compatibility
 
 ### Dependencies
 

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -200,9 +200,9 @@ module PaperTrail
     #
     # This is an "update" event. That is, we record the same data we would in
     # the case of a normal AR `update`.
-    def save_with_version(*args)
+    def save_with_version(**args)
       ::PaperTrail.request(enabled: false) do
-        @record.save(*args)
+        @record.save(**args)
       end
       record_update(force: true, in_after_callback: false, is_touch: false)
     end

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -200,9 +200,9 @@ module PaperTrail
     #
     # This is an "update" event. That is, we record the same data we would in
     # the case of a normal AR `update`.
-    def save_with_version(**args)
+    def save_with_version(**options)
       ::PaperTrail.request(enabled: false) do
-        @record.save(**args)
+        @record.save(**options)
       end
       record_update(force: true, in_after_callback: false, is_touch: false)
     end

--- a/spec/models/post_with_status_spec.rb
+++ b/spec/models/post_with_status_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe PostWithStatus, type: :model do
     end
 
     describe "#save_with_version" do
+      context "when passing *args" do
+        it "passes *args down correctly" do
+          post = described_class.create(status: :draft)
+          expect do
+            post.paper_trail.save_with_version(validate: false)
+          end.to change(post.versions, :count).by(1)
+        end
+      end
+
       it "preserves the enum value (and all other attributes)" do
         post = described_class.create(status: :draft)
         expect(post.versions.count).to eq(1)


### PR DESCRIPTION
Thanks for this amazing gem!

Rails 6.1. dropped `*args` for `ActiveRecord#save`, see [this commit](https://github.com/rails/rails/commit/57b4668c113b531f0b9a3e271b39aa19b686ab1d); commit message:

> `save` and `save!` doesn't take positional arguments
> 
> Some commits adds `**` to address kwargs warnings in Ruby 2.7, but
> `save` and `save!` are originally doesn't take positional arguments, so
> maintain both `*` and `**` is redundant.

Hence, using PaperTrail's `save_with_version` will fail using Rails >= 6.1.
To fix this, simply expand args passed to `save_with_version` using the double splat operator. If I understand the changelog of the above Rails' commit correctly, this change should be backward compatible (specs are passing for AR 5 locally).

### How to test
You probably have to update appraisal locally to verify this PR. Just undo the double splat, then run `DB=sqlite bundle exec appraisal rails-6.1 rake`; this will fail the newly added test.

<hr />
Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
