### PR TITLE
Touch callback does not always create version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - Expand kwargs passed to `save_with_version` using double splat operator - Rails 6.1 compatibility
 
+- [#1285](https://github.com/paper-trail-gem/paper_trail/pull/1285) -
+  Touch callback does not create a new version for skipped or ignored attributes
+  for ActiveRecord 6.0 and higher
+
 ### Dependencies
 
 - Drop support for ruby 2.4 (reached EoL on 2020-03-31)

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -101,7 +101,7 @@ module PaperTrail
     def on_touch
       @model_class.after_touch { |r|
         r.paper_trail.record_update(
-          force: true,
+          force: RAILS_LT_6_0,
           in_after_callback: true,
           is_touch: true
         )
@@ -127,6 +127,9 @@ module PaperTrail
     end
 
     private
+
+    RAILS_LT_6_0 = ::ActiveRecord.gem_version < ::Gem::Version.new("6.0.0")
+    private_constant :RAILS_LT_6_0
 
     # Raises an error if the provided class is an `abstract_class`.
     # @api private

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -19,6 +19,48 @@ RSpec.describe Skipper, type: :model, versioning: true do
     end
   end
 
+  describe "#touch" do
+    let(:t1) { Time.zone.local(2015, 7, 15, 20, 34, 0) }
+    let(:t2) { Time.zone.local(2015, 7, 15, 20, 34, 30) }
+
+    if ActiveRecord.gem_version >= Gem::Version.new("6")
+      it "does not create a version for skipped attributes" do
+        skipper = Skipper.create!(another_timestamp: t1)
+        expect {
+          skipper.touch(:another_timestamp, time: t2)
+        }.not_to(change { skipper.versions.length })
+      end
+
+      it "does not create a version for ignored attributes" do
+        skipper = Skipper.create!(created_at: t1)
+        expect {
+          skipper.touch(:created_at, time: t2)
+        }.not_to(change { skipper.versions.length })
+      end
+    else
+      it "creates a version even for skipped attributes" do
+        skipper = Skipper.create!(another_timestamp: t1)
+        expect {
+          skipper.touch(:another_timestamp, time: t2)
+        }.to(change { skipper.versions.length })
+      end
+
+      it "creates a version even for ignored attributes" do
+        skipper = Skipper.create!(created_at: t1)
+        expect {
+          skipper.touch(:created_at, time: t2)
+        }.to(change { skipper.versions.length })
+      end
+    end
+
+    it "creates a version for non-skipped timestamps" do
+      skipper = Skipper.create!
+      expect {
+        skipper.touch
+      }.to(change { skipper.versions.length })
+    end
+  end
+
   describe "#reify" do
     let(:t1) { Time.zone.local(2015, 7, 15, 20, 34, 0) }
     let(:t2) { Time.zone.local(2015, 7, 15, 20, 34, 30) }


### PR DESCRIPTION
Currently `touch` with an ignored or skipped attribute will still create a new version. This changes the behavior to make it consistent with `update` callback.