### PR TITLE
Fix 'rails db:migrate' error when run against an app with mysql2 adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 ### Fixed
 
 - Expand kwargs passed to `save_with_version` using double splat operator - Rails 6.1 compatibility
+- [#1287](https://github.com/paper-trail-gem/paper_trail/issues/1287) - Fix 'rails db:migrate' error when run against an app with mysql2 adapter
 
 ### Dependencies
 

--- a/lib/generators/paper_trail/install/install_generator.rb
+++ b/lib/generators/paper_trail/install/install_generator.rb
@@ -68,7 +68,7 @@ module PaperTrail
     #
     def versions_table_options
       if mysql?
-        ', { options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" }'
+        ', options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"'
       else
         ""
       end

--- a/spec/generators/paper_trail/install_generator_spec.rb
+++ b/spec/generators/paper_trail/install_generator_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
       }.call
       expected_create_table_options = lambda {
         if described_class::MYSQL_ADAPTERS.include?(ActiveRecord::Base.connection.class.name)
-          ', { options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" }'
+          ', options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"'
         else
           ""
         end


### PR DESCRIPTION
Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/

Fixes #1287 
