### PR TITLE
Introduce PaperTrail::Error class

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -8,6 +8,7 @@
 # can revisit this decision.
 require "active_support/all"
 
+require "paper_trail/errors"
 require "paper_trail/cleaner"
 require "paper_trail/compatibility"
 require "paper_trail/config"
@@ -78,7 +79,7 @@ module PaperTrail
     # Set the field which records when a version was created.
     # @api public
     def timestamp_field=(_field_name)
-      raise(E_TIMESTAMP_FIELD_CONFIG)
+      raise Error, E_TIMESTAMP_FIELD_CONFIG
     end
 
     # Set the PaperTrail serializer. This setting affects all threads.

--- a/lib/paper_trail/errors.rb
+++ b/lib/paper_trail/errors.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PaperTrail
+  # Generic PaperTrail exception.
+  # @api public
+  class Error < StandardError
+  end
+
+  # An unexpected option, perhaps a typo, was passed to a public API method.
+  # @api public
+  class InvalidOption < Error
+  end
+end

--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -58,7 +58,7 @@ module PaperTrail
       end
 
       if recording_order.to_s == "after" && cannot_record_after_destroy?
-        raise E_CANNOT_RECORD_AFTER_DESTROY
+        raise Error, E_CANNOT_RECORD_AFTER_DESTROY
       end
 
       @model_class.send(
@@ -143,7 +143,7 @@ module PaperTrail
     # @api private
     def assert_concrete_activerecord_class(class_name)
       if class_name.constantize.abstract_class?
-        raise format(E_HPT_ABSTRACT_CLASS, @model_class, class_name)
+        raise Error, format(E_HPT_ABSTRACT_CLASS, @model_class, class_name)
       end
     end
 
@@ -158,7 +158,7 @@ module PaperTrail
     def check_presence_of_item_subtype_column(options)
       return unless options.key?(:limit)
       return if version_class.item_subtype_column_present?
-      raise format(E_MODEL_LIMIT_REQUIRES_ITEM_SUBTYPE, @model_class.name)
+      raise Error, format(E_MODEL_LIMIT_REQUIRES_ITEM_SUBTYPE, @model_class.name)
     end
 
     def check_version_class_name(options)

--- a/lib/paper_trail/queries/versions/where_object.rb
+++ b/lib/paper_trail/queries/versions/where_object.rb
@@ -19,7 +19,7 @@ module PaperTrail
         # @api private
         def execute
           column = @version_model_class.columns_hash["object"]
-          raise "where_object can't be called without an object column" unless column
+          raise Error, "where_object requires an object column" unless column
 
           case column.type
           when :jsonb

--- a/lib/paper_trail/request.rb
+++ b/lib/paper_trail/request.rb
@@ -12,9 +12,6 @@ module PaperTrail
   #
   # @api private
   module Request
-    class InvalidOption < RuntimeError
-    end
-
     class << self
       # Sets any data from the controller that you want PaperTrail to store.
       # See also `PaperTrail::Rails::Controller#info_for_paper_trail`.

--- a/lib/paper_trail/serializers/json.rb
+++ b/lib/paper_trail/serializers/json.rb
@@ -16,7 +16,7 @@ module PaperTrail
 
       # Raises an exception as this operation is not allowed from text columns.
       def where_attribute_changes(*)
-        raise <<-STR.squish.freeze
+        raise Error, <<-STR.squish.freeze
           where_attribute_changes does not support reading JSON from a text
           column. The json and jsonb datatypes are supported.
         STR
@@ -41,7 +41,7 @@ module PaperTrail
       end
 
       def where_object_changes_condition(*)
-        raise <<-STR.squish.freeze
+        raise Error, <<-STR.squish.freeze
           where_object_changes no longer supports reading JSON from a text
           column. The old implementation was inaccurate, returning more records
           than you wanted. This feature was deprecated in 7.1.0 and removed in
@@ -52,7 +52,7 @@ module PaperTrail
 
       # Raises an exception as this operation is not allowed from text columns.
       def where_object_changes_from_condition(*)
-        raise <<-STR.squish.freeze
+        raise Error, <<-STR.squish.freeze
           where_object_changes_from does not support reading JSON from a text
           column. The json and jsonb datatypes are supported.
         STR
@@ -60,7 +60,7 @@ module PaperTrail
 
       # Raises an exception as this operation is not allowed from text columns.
       def where_object_changes_to_condition(*)
-        raise <<-STR.squish.freeze
+        raise Error, <<-STR.squish.freeze
           where_object_changes_to does not support reading JSON from a text
           column. The json and jsonb datatypes are supported.
         STR

--- a/lib/paper_trail/serializers/yaml.rb
+++ b/lib/paper_trail/serializers/yaml.rb
@@ -23,7 +23,7 @@ module PaperTrail
 
       # Raises an exception as this operation is not allowed from text columns.
       def where_attribute_changes(*)
-        raise <<-STR.squish.freeze
+        raise Error, <<-STR.squish.freeze
           where_attribute_changes does not support reading YAML from a text
           column. The json and jsonb datatypes are supported.
         STR
@@ -38,7 +38,7 @@ module PaperTrail
       # Returns a SQL LIKE condition to be used to match the given field and
       # value in the serialized `object_changes`.
       def where_object_changes_condition(*)
-        raise <<-STR.squish.freeze
+        raise Error, <<-STR.squish.freeze
           where_object_changes no longer supports reading YAML from a text
           column. The old implementation was inaccurate, returning more records
           than you wanted. This feature was deprecated in 8.1.0 and removed in
@@ -49,7 +49,7 @@ module PaperTrail
 
       # Raises an exception as this operation is not allowed with YAML.
       def where_object_changes_from_condition(*)
-        raise <<-STR.squish.freeze
+        raise Error, <<-STR.squish.freeze
           where_object_changes_from does not support reading YAML from a text
           column. The json and jsonb datatypes are supported.
         STR
@@ -57,7 +57,7 @@ module PaperTrail
 
       # Raises an exception as this operation is not allowed with YAML.
       def where_object_changes_to_condition(*)
-        raise <<-STR.squish.freeze
+        raise Error, <<-STR.squish.freeze
           where_object_changes_to does not support reading YAML from a text
           column. The json and jsonb datatypes are supported.
         STR

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -266,7 +266,7 @@ module PaperTrail
     #
     def reify(options = {})
       unless self.class.column_names.include? "object"
-        raise "reify can't be called without an object column"
+        raise Error, "reify requires an object column"
       end
       return nil if object.nil?
       ::PaperTrail::Reifier.reify(self, options)

--- a/spec/models/no_object_spec.rb
+++ b/spec/models/no_object_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe NoObject, versioning: true do
       v = n.versions.last
       expect { v.reify }.to(
         raise_error(
-          ::RuntimeError,
-          "reify can't be called without an object column"
+          ::PaperTrail::Error,
+          "reify requires an object column"
         )
       )
     end
@@ -56,8 +56,8 @@ RSpec.describe NoObject, versioning: true do
         n.versions.where_object(foo: "bar")
       }.to(
         raise_error(
-          ::RuntimeError,
-          "where_object can't be called without an object column"
+          ::PaperTrail::Error,
+          "where_object requires an object column"
         )
       )
     end

--- a/spec/paper_trail/request_spec.rb
+++ b/spec/paper_trail/request_spec.rb
@@ -140,7 +140,7 @@ module PaperTrail
               end
             end
 
-            expect { subject.call }.to raise_error(PaperTrail::Request::InvalidOption) do |e|
+            expect { subject.call }.to raise_error(PaperTrail::InvalidOption) do |e|
               expect(e.message).to eq "Invalid option: invalid_option"
             end
           end
@@ -154,7 +154,7 @@ module PaperTrail
               end
             end
 
-            expect { subject.call }.to raise_error(PaperTrail::Request::InvalidOption) do |e|
+            expect { subject.call }.to raise_error(PaperTrail::InvalidOption) do |e|
               expect(e.message).to eq "Invalid option: invalid_option"
             end
           end


### PR DESCRIPTION
Following the example of e.g. `active_record/errors.rb`