### PR TITLE
Queries: object_changes: Simplify error instantiation

### DIFF
--- a/lib/paper_trail/errors.rb
+++ b/lib/paper_trail/errors.rb
@@ -10,4 +10,24 @@ module PaperTrail
   # @api public
   class InvalidOption < Error
   end
+
+  # The application's database schema is not supported.
+  # @api public
+  class UnsupportedSchema < Error
+  end
+
+  # The application's database column type is not supported.
+  # @api public
+  class UnsupportedColumnType < UnsupportedSchema
+    def initialize(method:, expected:, actual:)
+      super(
+        format(
+          "%s expected %s column, got %s",
+          method,
+          expected,
+          actual
+        )
+      )
+    end
+  end
 end

--- a/lib/paper_trail/queries/versions/where_attribute_changes.rb
+++ b/lib/paper_trail/queries/versions/where_attribute_changes.rb
@@ -23,12 +23,16 @@ module PaperTrail
               @version_model_class, @attribute
             )
           end
-
-          case @version_model_class.columns_hash["object_changes"].type
+          column_type = @version_model_class.columns_hash["object_changes"].type
+          case column_type
           when :jsonb, :json
             json
           else
-            text
+            raise UnsupportedColumnType.new(
+              method: "where_attribute_changes",
+              expected: "json or jsonb",
+              actual: column_type
+            )
           end
         end
 
@@ -39,15 +43,6 @@ module PaperTrail
           sql = "object_changes -> ? IS NOT NULL"
 
           @version_model_class.where(sql, @attribute)
-        end
-
-        # @api private
-        def text
-          arel_field = @version_model_class.arel_table[:object_changes]
-
-          @version_model_class.where(
-            ::PaperTrail.serializer.where_attribute_changes(arel_field, @attribute)
-          )
         end
       end
     end

--- a/lib/paper_trail/queries/versions/where_object_changes_from.rb
+++ b/lib/paper_trail/queries/versions/where_object_changes_from.rb
@@ -23,12 +23,16 @@ module PaperTrail
               @version_model_class, @attributes
             )
           end
-
-          case @version_model_class.columns_hash["object_changes"].type
+          column_type = @version_model_class.columns_hash["object_changes"].type
+          case column_type
           when :jsonb, :json
             json
           else
-            text
+            raise UnsupportedColumnType.new(
+              method: "where_object_changes_from",
+              expected: "json or jsonb",
+              actual: column_type
+            )
           end
         end
 
@@ -46,18 +50,6 @@ module PaperTrail
           end
           sql = predicates.join(" and ")
           @version_model_class.where(sql, *values)
-        end
-
-        # @api private
-        def text
-          arel_field = @version_model_class.arel_table[:object_changes]
-
-          where_conditions = @attributes.map do |field, value|
-            ::PaperTrail.serializer.where_object_changes_from_condition(arel_field, field, value)
-          end
-
-          where_conditions = where_conditions.reduce { |a, e| a.and(e) }
-          @version_model_class.where(where_conditions)
         end
       end
     end

--- a/lib/paper_trail/serializers/json.rb
+++ b/lib/paper_trail/serializers/json.rb
@@ -14,14 +14,6 @@ module PaperTrail
         ActiveSupport::JSON.encode object
       end
 
-      # Raises an exception as this operation is not allowed from text columns.
-      def where_attribute_changes(*)
-        raise Error, <<-STR.squish.freeze
-          where_attribute_changes does not support reading JSON from a text
-          column. The json and jsonb datatypes are supported.
-        STR
-      end
-
       # Returns a SQL LIKE condition to be used to match the given field and
       # value in the serialized object.
       def where_object_condition(arel_field, field, value)
@@ -38,32 +30,6 @@ module PaperTrail
         else
           arel_field.matches("%\"#{field}\":#{json_value}%")
         end
-      end
-
-      def where_object_changes_condition(*)
-        raise Error, <<-STR.squish.freeze
-          where_object_changes no longer supports reading JSON from a text
-          column. The old implementation was inaccurate, returning more records
-          than you wanted. This feature was deprecated in 7.1.0 and removed in
-          8.0.0. The json and jsonb datatypes are still supported. See the
-          discussion at https://github.com/paper-trail-gem/paper_trail/issues/803
-        STR
-      end
-
-      # Raises an exception as this operation is not allowed from text columns.
-      def where_object_changes_from_condition(*)
-        raise Error, <<-STR.squish.freeze
-          where_object_changes_from does not support reading JSON from a text
-          column. The json and jsonb datatypes are supported.
-        STR
-      end
-
-      # Raises an exception as this operation is not allowed from text columns.
-      def where_object_changes_to_condition(*)
-        raise Error, <<-STR.squish.freeze
-          where_object_changes_to does not support reading JSON from a text
-          column. The json and jsonb datatypes are supported.
-        STR
       end
     end
   end

--- a/lib/paper_trail/serializers/yaml.rb
+++ b/lib/paper_trail/serializers/yaml.rb
@@ -21,46 +21,10 @@ module PaperTrail
         ::YAML.dump object
       end
 
-      # Raises an exception as this operation is not allowed from text columns.
-      def where_attribute_changes(*)
-        raise Error, <<-STR.squish.freeze
-          where_attribute_changes does not support reading YAML from a text
-          column. The json and jsonb datatypes are supported.
-        STR
-      end
-
       # Returns a SQL LIKE condition to be used to match the given field and
       # value in the serialized object.
       def where_object_condition(arel_field, field, value)
         arel_field.matches("%\n#{field}: #{value}\n%")
-      end
-
-      # Returns a SQL LIKE condition to be used to match the given field and
-      # value in the serialized `object_changes`.
-      def where_object_changes_condition(*)
-        raise Error, <<-STR.squish.freeze
-          where_object_changes no longer supports reading YAML from a text
-          column. The old implementation was inaccurate, returning more records
-          than you wanted. This feature was deprecated in 8.1.0 and removed in
-          9.0.0. The json and jsonb datatypes are still supported. See
-          discussion at https://github.com/paper-trail-gem/paper_trail/pull/997
-        STR
-      end
-
-      # Raises an exception as this operation is not allowed with YAML.
-      def where_object_changes_from_condition(*)
-        raise Error, <<-STR.squish.freeze
-          where_object_changes_from does not support reading YAML from a text
-          column. The json and jsonb datatypes are supported.
-        STR
-      end
-
-      # Raises an exception as this operation is not allowed with YAML.
-      def where_object_changes_to_condition(*)
-        raise Error, <<-STR.squish.freeze
-          where_object_changes_to does not support reading YAML from a text
-          column. The json and jsonb datatypes are supported.
-        STR
       end
     end
   end

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module PaperTrail
   ::RSpec.describe Version, type: :model do
-    describe "object_changes column", versioning: true do
+    describe "#object_changes", versioning: true do
       let(:widget) { Widget.create!(name: "Dashboard") }
       let(:value) { widget.versions.last.object_changes }
 
@@ -190,9 +190,12 @@ module PaperTrail
                     bicycle.versions.where_attribute_changes(:name)
                   ).to match_array([bicycle.versions[0], bicycle.versions[1]])
                 else
-                  expect do
+                  expect {
                     bicycle.versions.where_attribute_changes(:name)
-                  end.to raise_error(/does not support reading YAML/)
+                  }.to raise_error(
+                    UnsupportedColumnType,
+                    "where_attribute_changes expected json or jsonb column, got text"
+                  )
                 end
               end
             end
@@ -218,7 +221,10 @@ module PaperTrail
               it "raises error" do
                 expect {
                   widget.versions.where_attribute_changes(:name).to_a
-                }.to(raise_error(/does not support reading YAML from a text column/))
+                }.to raise_error(
+                  UnsupportedColumnType,
+                  "where_attribute_changes expected json or jsonb column, got text"
+                )
               end
             end
           end
@@ -311,9 +317,12 @@ module PaperTrail
                     bicycle.versions.where_object_changes(name: "abc")
                   ).to match_array(bicycle.versions[0..1])
                 else
-                  expect do
+                  expect {
                     bicycle.versions.where_object_changes(name: "abc")
-                  end.to raise_error(/no longer supports reading YAML/)
+                  }.to raise_error(
+                    UnsupportedColumnType,
+                    "where_object_changes expected json or jsonb column, got text"
+                  )
                 end
               end
             end
@@ -342,7 +351,10 @@ module PaperTrail
               it "raises error" do
                 expect {
                   widget.versions.where_object_changes(name: "foo").to_a
-                }.to(raise_error(/no longer supports reading YAML from a text column/))
+                }.to raise_error(
+                  UnsupportedColumnType,
+                  "where_object_changes expected json or jsonb column, got text"
+                )
               end
             end
           end
@@ -389,9 +401,12 @@ module PaperTrail
                     bicycle.versions.where_object_changes_from(name: "abc")
                   ).to match_array([bicycle.versions[1]])
                 else
-                  expect do
+                  expect {
                     bicycle.versions.where_object_changes_from(name: "abc")
-                  end.to raise_error(/does not support reading YAML/)
+                  }.to raise_error(
+                    UnsupportedColumnType,
+                    "where_object_changes_from expected json or jsonb column, got text"
+                  )
                 end
               end
             end
@@ -421,7 +436,10 @@ module PaperTrail
               it "raises error" do
                 expect {
                   widget.versions.where_object_changes_from(name: "foo").to_a
-                }.to(raise_error(/does not support reading YAML from a text column/))
+                }.to raise_error(
+                  UnsupportedColumnType,
+                  "where_object_changes_from expected json or jsonb column, got text"
+                )
               end
             end
           end
@@ -468,9 +486,12 @@ module PaperTrail
                     bicycle.versions.where_object_changes_to(name: "xyz")
                   ).to match_array([bicycle.versions[1]])
                 else
-                  expect do
+                  expect {
                     bicycle.versions.where_object_changes_to(name: "xyz")
-                  end.to raise_error(/does not support reading YAML/)
+                  }.to raise_error(
+                    UnsupportedColumnType,
+                    "where_object_changes_to expected json or jsonb column, got text"
+                  )
                 end
               end
             end
@@ -503,7 +524,10 @@ module PaperTrail
               it "raises error" do
                 expect {
                   widget.versions.where_object_changes_to(name: "foo").to_a
-                }.to(raise_error(/does not support reading YAML from a text column/))
+                }.to raise_error(
+                  UnsupportedColumnType,
+                  "where_object_changes_to expected json or jsonb column, got text"
+                )
               end
             end
           end

--- a/spec/paper_trail/serializers/json_spec.rb
+++ b/spec/paper_trail/serializers/json_spec.rb
@@ -59,14 +59,6 @@ module PaperTrail
           end
         end
       end
-
-      describe ".where_object_changes_condition" do
-        it "raises error" do
-          expect {
-            described_class.where_object_changes_condition
-          }.to raise_error(/no longer supports/)
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
- Introduces a uniform error class, UnsupportedColumnType
- Simplifies the built-in serializers (paper_trail/serializers)

Since 9.2.0, when `object_changes_adapter` was introduced, if someone must use a
text column, and still wants to use these queries, they must write an
`object_changes_adapter`. AFAIK, no one has ever done this. The only public
adapter I know of, paper_trail-hashdiff, only supports json/b columns.

It's also theoretically possible that, after `where_object_changes` dropped
support for text columns, someone wrote a custom serializer (see
`PaperTrail.serializer=`). AFAIK, no one has done that either. Such a technique
was never documented under [6.b. Custom
Serializer](https://github.com/paper-trail-gem/paper_trail#6b-custom-serializer)
