### PR TITLE
Change default object* column type from text to json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
+- Changes the default type of the `object` and `object_changes` columns, from
+  `text` to `json`.
 - [#1285](https://github.com/paper-trail-gem/paper_trail/pull/1285) -
   For ActiveRecord >= 6.0, the `touch` callback will no longer create a new
   `Version` for skipped or ignored attributes.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Experts: to install incompatible versions of activerecord, see
 1. Add a `versions` table to your database:
 
     ```
-    bundle exec rails generate paper_trail:install [--with-changes]
+    bundle exec rails generate paper_trail:install --with-changes
     ```
 
     For more information on this generator, see [section 5.c.
@@ -1105,10 +1105,20 @@ Be advised that redefining an association is an undocumented feature of Rails.
 ### 5.c. Generators
 
 PaperTrail has one generator, `paper_trail:install`. It writes, but does not
-run, a migration file.
-The migration adds (at least) the `versions` table. The
-most up-to-date documentation for this generator can be found by running `rails
-generate paper_trail:install --help`, but a copy is included here for
+run, a migration file. The migration creates the `versions` table.
+
+```
+rails generate paper_trail:install --with-changes
+```
+
+The `--with-changes` option is recommended. It adds an `object_changes` column,
+which enables [diffing](#3c-diffing-versions) and [queries](#3e-queries). This
+optional column can be deleted later, if necessary.
+
+#### Reference
+
+The most up-to-date documentation for this generator can be found by running
+`rails generate paper_trail:install --help`, but a copy is included here for
 convenience.
 
 ```

--- a/lib/generators/paper_trail/install/templates/add_object_changes_to_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/add_object_changes_to_versions.rb.erb
@@ -2,11 +2,7 @@
 # will store the `changes` diff for each update event. See the readme for
 # details.
 class AddObjectChangesToVersions < ActiveRecord::Migration<%= migration_version %>
-  # The largest text column available in all supported RDBMS.
-  # See `create_versions.rb` for details.
-  TEXT_BYTES = 1_073_741_823
-
   def change
-    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+    add_column :versions, :object_changes, :json
   end
 end

--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -1,20 +1,13 @@
 # This migration creates the `versions` table, the only schema PT requires.
 # All other migrations PT provides are optional.
 class CreateVersions < ActiveRecord::Migration<%= migration_version %>
-
-  # The largest text column available in all supported RDBMS is
-  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
-  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
-  # when serializing very large objects, `text` might not be big enough.
-  TEXT_BYTES = 1_073_741_823
-
   def change
     create_table :versions<%= versions_table_options %> do |t|
       t.string   :item_type<%= item_type_options %>
       t.bigint   :item_id,   null: false
       t.string   :event,     null: false
       t.string   :whodunnit
-      t.text     :object, limit: TEXT_BYTES
+      t.json :object
 
       # Known issue in MySQL: fractional second precision
       # -------------------------------------------------

--- a/spec/generators/paper_trail/install_generator_spec.rb
+++ b/spec/generators/paper_trail/install_generator_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
               migration("add_object_changes_to_versions") {
                 contains "class AddObjectChangesToVersions"
                 contains "def change"
-                contains "add_column :versions, :object_changes, :text"
+                contains "add_column :versions, :object_changes, :json"
               }
             }
           }


### PR DESCRIPTION
- It's hard to change _post facto_
- Our object_changes query methods do not support text columns
- MySQL has some support for json columns now
  (https://dev.mysql.com/doc/refman/8.0/en/json.html)
- If you have to use text, you can edit your migration
