### PR TITLE
 Add option to avoid making a database connection during install. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
+- Add option --with-mysql
+  Prevents the installer form making a database connection during install.
+  If false (default) the database type will be determined automatically at the cost of a database connection, which might not be available at install time.
+
 ### Breaking Changes
 
 - None

--- a/lib/generators/paper_trail/install/install_generator.rb
+++ b/lib/generators/paper_trail/install/install_generator.rb
@@ -20,6 +20,12 @@ module PaperTrail
       default: false,
       desc: "Store changeset (diff) with each version"
     )
+    class_option(
+      :with_mysql,
+      type: :boolean,
+      default: false,
+      desc: "Use mysql adapter. Prevents the installer form making a database connection during install. If false (default) the database type will be determined automatically at the cost of a database connection, which might not be available at install time."
+    )
 
     desc "Generates (but does not run) a migration to add a versions table." \
          "  See section 5.c. Generators in README.md for more information."
@@ -48,7 +54,7 @@ module PaperTrail
     end
 
     def mysql?
-      MYSQL_ADAPTERS.include?(ActiveRecord::Base.connection.class.name)
+      options.with_mysql? || MYSQL_ADAPTERS.include?(ActiveRecord::Base.connection.class.name)
     end
 
     # Even modern versions of MySQL still use `latin1` as the default character


### PR DESCRIPTION
Add option --with-mysql
Prevents the installer form making a database connection during install.
If false (default) the database type will be determined automatically at the cost of a database connection, which might not be available at install time."

Thank you for your contribution!

Check the following boxes:

- [X ] Wrote [good commit messages][1].
- [ X] Feature branch is up-to-date with `master` (if not - rebase it).
- [ X] Squashed related commits together.
- [O] Added tests.
- [X ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [X ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
