### PR TITLE
Reference bug report template with kebab rather than snake cased filename

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -139,4 +139,4 @@ markdown-toc -i --maxdepth 3 --bullets='-' README.md
   1. cherry-pick the "Release 10.3.0" commit from the `10-stable` branch
   1. git push origin master
 
-[1]: https://github.com/paper-trail-gem/paper_trail/blob/master/.github/ISSUE_TEMPLATE/bug_report.md
+[1]: https://github.com/paper-trail-gem/paper_trail/blob/master/.github/ISSUE_TEMPLATE/bug-report.md

--- a/.github/ISSUE_TEMPLATE/feature-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature-suggestion.md
@@ -15,7 +15,7 @@ closed without comment.
 **Is your feature suggestion related to a problem? Please describe.**
 
 A clear and concise description of the problem. You may find the
-[bug report template](https://github.com/paper-trail-gem/paper_trail/blob/master/.github/ISSUE_TEMPLATE/bug_report.md)
+[bug report template](https://github.com/paper-trail-gem/paper_trail/blob/master/.github/ISSUE_TEMPLATE/bug-report.md)
 helpful.
 
 **Describe the solution you'd like to build**

--- a/doc/bug_report_template.rb
+++ b/doc/bug_report_template.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-# Moved to .github/ISSUE_TEMPLATE/bug_report.md
+# Moved to .github/ISSUE_TEMPLATE/bug-report.md
 # Please update your bookmarks

--- a/doc/triage.md
+++ b/doc/triage.md
@@ -13,7 +13,7 @@ For instructions on how to file a bug report, please see our [issue template][3]
 
 [1]: https://github.com/paper-trail-gem/paper_trail/blob/master/.github/CONTRIBUTING.md
 [2]: https://stackoverflow.com/tags/paper-trail-gem
-[3]: https://github.com/paper-trail-gem/paper_trail/blob/master/.github/ISSUE_TEMPLATE/bug_report.md
+[3]: https://github.com/paper-trail-gem/paper_trail/blob/master/.github/ISSUE_TEMPLATE/bug-report.md
 ```
 
 ## Responses to Common Problems
@@ -24,7 +24,7 @@ Hi ___. All issues are required to use our [issue template][2]. See also our
 and I'll do what I can to help!
 
 [1]: https://github.com/paper-trail-gem/paper_trail/blob/master/.github/CONTRIBUTING.md
-[2]: https://github.com/paper-trail-gem/paper_trail/blob/master/.github/ISSUE_TEMPLATE/bug_report.md
+[2]: https://github.com/paper-trail-gem/paper_trail/blob/master/.github/ISSUE_TEMPLATE/bug-report.md
 ```
 
 ## Usage question masquerading as a feature proposal


### PR DESCRIPTION
All mentions of the bug report template in the repo refer to a file snake cased, while the files in `.github/ISSUE_TEMPLATE`are kebab cased. 
To fix the links all those mentions are updated with the correct casing.

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
