### PR TITLE
Problem: wrong schema created by the generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 - [#1285](https://github.com/paper-trail-gem/paper_trail/pull/1285) -
   For ActiveRecord >= 6.0, the `touch` callback will no longer create a new
   `Version` for skipped or ignored attributes.
+- Newly generated migrations won't generate a "{:null=>false}" column. Existing
+  tables will need to drop this column and make item_type non-nullable.
 
 ## 12.0.0 (2021-03-29)
 

--- a/lib/generators/paper_trail/install/install_generator.rb
+++ b/lib/generators/paper_trail/install/install_generator.rb
@@ -41,9 +41,9 @@ module PaperTrail
     # See https://github.com/paper-trail-gem/paper_trail/issues/651
     def item_type_options
       if mysql?
-        ", { null: false, limit: 191 }"
+        ", null: false, limit: 191"
       else
-        ", { null: false }"
+        ", null: false"
       end
     end
 


### PR DESCRIPTION
'rails generate paper_trail:install' generates a subtly wrong
schema.

```
$ rails generate paper_trail:install
      create  db/migrate/20210624155730_create_versions.rb
$ db:migrate
== 20210624155730 CreateVersions: migrating ===================================
-- create_table(:versions)
   -> 0.0010s
-- add_index(:versions, [:item_type, :item_id])
   -> 0.0003s
== 20210624155730 CreateVersions: migrated (0.0013s) ==========================
```

When you look into the created table, it has this funny "{:null=>false}"
column:

```
$ sqlite3 db/development.sqlite3
SQLite version 3.32.3 2020-06-18 14:16:19
Enter ".help" for usage hints.
sqlite> pragma table_info(versions);
0|id|integer|1||1
1|item_type|varchar|0||0
2|{:null=>false}|varchar|0||0
3|item_id|bigint|1||0
4|event|varchar|1||0
5|whodunnit|varchar|0||0
6|object|text(1073741823)|0||0
7|created_at|datetime|0||0
```

Solution: ensure proper column syntax is used

This comes from the first line in the `versions` table migration:

```ruby
t.string   :item_type, { null: false }
```

When `{ null: false }` is replaced with `null: false`, th
re-created schema looks like this:

```
$ sqlite3 db/development.sqlite3
SQLite version 3.32.3 2020-06-18 14:16:19
Enter ".help" for usage hints.
sqlite> pragma table_info(versions);
0|id|integer|1||1
1|item_type|varchar|1||0
2|item_id|bigint|1||0
3|event|varchar|1||0
4|whodunnit|varchar|0||0
5|object|text(1073741823)|0||0
6|created_at|datetime|0||0
```

This seems to come from this subtlety of how shorthand methods are implemented in
https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L261-L270

Specifically, I think the reason for the anove bug is that it'll hapilly iterate
over given names, whether they happen to be strings/symbols or not.

In the ideal world, perhaps `define_column_methods`' generated methods should have
verified if a given name is a `Hash` or not. But the world isn't ideal,
so I propose to address this issue in paper_trail. I may open a separate issue with
the Rails team to see if anything should be done on their end going further.

---

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
