### PR TITLE
Improve reification of STI classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 - [#1285](https://github.com/paper-trail-gem/paper_trail/pull/1285) -
   For ActiveRecord >= 6.0, the `touch` callback will no longer create a new
   `Version` for skipped or ignored attributes.
+- [#1333](https://github.com/paper-trail-gem/paper_trail/pull/1333) -
+  Improve reification of STI models that use `find_sti_class`/`sti_class_for`
+  to customize single table inheritance.
 
 ## 12.0.0 (2021-03-29)
 

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -109,14 +109,22 @@ module PaperTrail
       end
 
       # Given a `version`, return the class to reify. This method supports
-      # Single Table Inheritance (STI) with custom inheritance columns.
+      # Single Table Inheritance (STI) with custom inheritance columns and
+      # custom inheritance column values.
       #
       # For example, imagine a `version` whose `item_type` is "Animal". The
       # `animals` table is an STI table (it has cats and dogs) and it has a
       # custom inheritance column, `species`. If `attrs["species"]` is "Dog",
       # this method returns the constant `Dog`. If `attrs["species"]` is blank,
-      # this method returns the constant `Animal`. You can see this particular
-      # example in action in `spec/models/animal_spec.rb`.
+      # this method returns the constant `Animal`.
+      #
+      # The values contained in the inheritance columns may be non-camelized
+      # strings (e.g. 'dog' instead of 'Dog'). To reify classes in this case
+      # we need to call the parents class `sti_class_for` method to retrieve
+      # the correct record class.
+      #
+      # You can see these particular examples in action in
+      # `spec/models/animal_spec.rb` and `spec/models/plant_spec.rb`
       def version_reification_class(version, attrs)
         clazz = version.item_type.constantize
         inheritance_column_name = clazz.inheritance_column

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -117,13 +117,19 @@ module PaperTrail
       # this method returns the constant `Dog`. If `attrs["species"]` is blank,
       # this method returns the constant `Animal`. You can see this particular
       # example in action in `spec/models/animal_spec.rb`.
-      #
-      # TODO: Duplication: similar `constantize` in VersionConcern#version_limit
       def version_reification_class(version, attrs)
-        inheritance_column_name = version.item_type.constantize.inheritance_column
+        clazz = version.item_type.constantize
+        inheritance_column_name = clazz.inheritance_column
         inher_col_value = attrs[inheritance_column_name]
-        class_name = inher_col_value.blank? ? version.item_type : inher_col_value
-        class_name.constantize
+        return clazz if inher_col_value.blank?
+
+        # Rails 6.1 adds a public method for clients to use to customize STI classes. If that
+        # method is not available, fall back to using the private one
+        if clazz.public_methods.include?(:sti_class_for)
+          return clazz.sti_class_for(inher_col_value)
+        end
+
+        clazz.send(:find_sti_class, inher_col_value)
       end
     end
   end

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -375,7 +375,6 @@ module PaperTrail
     # The version limit can be global or per-model.
     #
     # @api private
-    #
     def version_limit
       if limit_option?(item.class)
         item.class.paper_trail_options[:limit]

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -380,7 +380,6 @@ module PaperTrail
     #
     # @api private
     #
-    # TODO: Duplication: similar `constantize` in Reifier#version_reification_class
     def version_limit
       if self.class.item_subtype_column_present?
         klass = (item_subtype || item_type).constantize

--- a/spec/dummy_app/app/models/plant.rb
+++ b/spec/dummy_app/app/models/plant.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Plant < ActiveRecord::Base
+  has_paper_trail
+  self.inheritance_column = "species"
+
+  class << self
+    # Rails 6.1 adds a public method to overwrite sti finder methods. In earlier versions, users
+    # may use the private method find_sti_class.
+    #
+    # See https://github.com/rails/rails/pull/37500
+    if method_defined?(:sti_class_for)
+      def sti_class_for(type_name)
+        super(type_name.camelize)
+      end
+    else
+      def find_sti_class(type_name)
+        super(type_name.camelize)
+      end
+    end
+  end
+end

--- a/spec/dummy_app/app/models/tomato.rb
+++ b/spec/dummy_app/app/models/tomato.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Tomato < Plant
+  class << self
+    def sti_name
+      "tomato"
+    end
+  end
+end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -230,6 +230,10 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.integer :animal_id
     end
 
+    create_table :plants, force: true do |t|
+      t.string :species # custom single table inheritance column
+    end
+
     create_table :documents, force: true do |t|
       t.string :name
     end

--- a/spec/models/plant_spec.rb
+++ b/spec/models/plant_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Plant, type: :model, versioning: true do
+  it "baseline test setup" do
+    expect(Plant.new).to be_versioned
+    expect(Plant.inheritance_column).to eq("species")
+  end
+
+  describe "#descends_from_active_record?" do
+    it "returns true, meaning that Animal is not an STI subclass" do
+      expect(described_class.descends_from_active_record?).to eq(true)
+    end
+  end
+
+  it "works with non standard STI column contents" do
+    plant = Plant.create
+    plant.destroy
+
+    tomato = Tomato.create
+    tomato.destroy
+
+    reified = plant.versions.last.reify
+    expect(reified.class).to eq(Plant)
+
+    reified = tomato.versions.last.reify
+    expect(reified.class).to eq(Tomato)
+  end
+end


### PR DESCRIPTION
Checklist

- [X] Wrote [good commit messages][1].
- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [X] Added tests.
- [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
  
This fixes #1332. 

As discussed, two commits were created, one with failing test cases and one to fix them. Some details about this solution: 

I opted to add a new test model, rather than an modify an existing one (e.g. `Animal`) to better represent the specific edge case described in the issue. 

Futhermore, as `sti_class_for` was only added recently (Rails 6.1), reification falls back to calling the private method `find_sti_class`. I could not find another way to keep tests for older versions of Rails passing. 

I left the commits unsquashed for transparency, feel free to squash when merging. 