### PR TITLE
Support Psych version 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1338](https://github.com/paper-trail-gem/paper_trail/pull/1338) -
+  Support Psych version 4
 
 ## 12.1.0 (2021-08-30)
 

--- a/lib/paper_trail/serializers/yaml.rb
+++ b/lib/paper_trail/serializers/yaml.rb
@@ -9,7 +9,7 @@ module PaperTrail
       extend self # makes all instance methods become module methods as well
 
       def load(string)
-        ::YAML.load string
+        ::YAML.respond_to?(:unsafe_load) ? ::YAML.unsafe_load(string) : ::YAML.load(string)
       end
 
       # @param object (Hash | HashWithIndifferentAccess) - Coming from

--- a/spec/paper_trail/serializers/yaml_spec.rb
+++ b/spec/paper_trail/serializers/yaml_spec.rb
@@ -22,6 +22,19 @@ module PaperTrail
           expect(described_class.load(hash.to_yaml)).to eq(hash)
           expect(described_class.load(array.to_yaml)).to eq(array)
         end
+
+        it "calls the expected load method based on Psych version" do
+          # Psych 4+ implements .unsafe_load
+          if ::YAML.respond_to?(:unsafe_load)
+            allow(::YAML).to receive(:unsafe_load)
+            described_class.load("string")
+            expect(::YAML).to have_received(:unsafe_load)
+          else # Psych < 4
+            allow(::YAML).to receive(:load)
+            described_class.load("string")
+            expect(::YAML).to have_received(:load)
+          end
+        end
       end
 
       describe ".dump" do


### PR DESCRIPTION
Fixes #1335

Psych's `.load` method uses `.safe_load` by default which is not compatible with papertail needs to load.

This implements the suggested fix in the issue which is a similar fix Rails uses throughout its codebase when it needs to load YAML content.

The test case outlined in the issue passes with this change (after I pointed the paperclip gem to the forked branch).

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
