### PR TITLE
Add specific instructions for MySQL migration

### DIFF
--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -28,7 +28,9 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
       # MySQL users should also upgrade to at least rails 4.2, which is the first
       # version of ActiveRecord with support for fractional seconds in MySQL.
       # (https://github.com/rails/rails/pull/14359)
-      #
+      # 
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6                                        
       t.datetime :created_at
     end
     add_index :versions, %i(item_type item_id)


### PR DESCRIPTION
The currently generated migration mentions that MySQL users should explicitly enable "fractional seconds precision", but doesn't provide specific steps to enable this. The user has to click the links to figure out what to do.
This change adds the specific migration statement that can be used.

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] ~~Added tests.~~
- [x] ~~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.~~
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
