### PR TITLE
run tests agains rails 7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       # have set this up with each database as a separate job, but then we'd be
       # duplicating the matrix configuration three times.
       matrix:
-        gemfile: [ 'rails_5.2', 'rails_6.0', 'rails_6.1' ]
+        gemfile: [ 'rails_5.2', 'rails_6.0', 'rails_6.1', 'rails_7.0' ]
 
         # To keep matrix size down, only test highest and lowest rubies.
         # Ruby 3.0 is an exception. For now, let's continue to test against 2.7
@@ -72,6 +72,9 @@ jobs:
             gemfile: 'rails_5.2'
           - ruby: '3.1'
             gemfile: 'rails_5.2'
+          # rails 7 requires ruby > 2.7
+          - ruby: '2.6'
+            gemfile: 'rails_7.0'
     steps:
       - name: Checkout source
         uses: actions/checkout@v2


### PR DESCRIPTION
looks like we've missed the update for the tests to run againts rails 7 in https://github.com/paper-trail-gem/paper_trail/pull/1365

- [ ] Wrote [good commit messages][1].
- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
