### PR TITLE
Added in_after_callback argument to save_with_version

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -50,6 +50,7 @@ Security/YAMLLoad:
     - 'spec/models/book_spec.rb'
     - 'spec/models/gadget_spec.rb'
     - 'spec/models/no_object_spec.rb'
+    - 'spec/models/not_on_update_spec.rb'
     - 'spec/models/person_spec.rb'
     - 'spec/models/version_spec.rb'
     - 'spec/paper_trail/events/destroy_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -50,7 +50,6 @@ Security/YAMLLoad:
     - 'spec/models/book_spec.rb'
     - 'spec/models/gadget_spec.rb'
     - 'spec/models/no_object_spec.rb'
-    - 'spec/models/not_on_update_spec.rb'
     - 'spec/models/person_spec.rb'
     - 'spec/models/version_spec.rb'
     - 'spec/paper_trail/events/destroy_spec.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
+- Added `in_after_callback` argument to `PaperTrail::RecordTrail#save_with_version`,
+  to allow the caller to indicate if this method is being called during an `after`
+  callback. Defaults to `false`.
+
 ### Breaking Changes
 
 - None

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -194,15 +194,17 @@ module PaperTrail
     # Save, and create a version record regardless of options such as `:on`,
     # `:if`, or `:unless`.
     #
-    # Arguments are passed to `save`.
+    # `in_after_callback`: Indicates if this method is being called within an
+    #                      `after` callback. Defaults to `false`.
+    # `options`: Optional arguments passed to `save`.
     #
     # This is an "update" event. That is, we record the same data we would in
     # the case of a normal AR `update`.
-    def save_with_version(**options)
+    def save_with_version(in_after_callback: false, **options)
       ::PaperTrail.request(enabled: false) do
         @record.save(**options)
       end
-      record_update(force: true, in_after_callback: false, is_touch: false)
+      record_update(force: true, in_after_callback: in_after_callback, is_touch: false)
     end
 
     # Like the `update_column` method from `ActiveRecord::Persistence`, but also

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -144,6 +144,7 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
     end
 
     create_table :not_on_updates, force: true do |t|
+      t.string :name
       t.timestamps null: true, limit: 6
     end
 

--- a/spec/models/not_on_update_spec.rb
+++ b/spec/models/not_on_update_spec.rb
@@ -13,13 +13,12 @@ RSpec.describe NotOnUpdate, type: :model do
     end
 
     it "captures changes when in_after_callback is true" do
-      now = DateTime.now
-      record.updated_at = now
+      record.name = "test"
       record.paper_trail.save_with_version(in_after_callback: true)
       as_stored_in_version = HashWithIndifferentAccess[
         YAML.load(record.versions.last.object_changes)
       ]
-      expect(as_stored_in_version[:updated_at].last).to(eq(now))
+      expect(as_stored_in_version[:name].last).to(eq("test"))
     end
   end
 end

--- a/spec/models/not_on_update_spec.rb
+++ b/spec/models/not_on_update_spec.rb
@@ -11,5 +11,15 @@ RSpec.describe NotOnUpdate, type: :model do
         PaperTrail::Version.count
       }.by(+1)
     end
+
+    it "captures changes when in_after_callback is true" do
+      now = DateTime.now
+      record.updated_at = now
+      record.paper_trail.save_with_version(in_after_callback: true)
+      as_stored_in_version = HashWithIndifferentAccess[
+        YAML.load(record.versions.last.object_changes)
+      ]
+      expect(as_stored_in_version[:updated_at].last).to(eq(now))
+    end
   end
 end

--- a/spec/models/not_on_update_spec.rb
+++ b/spec/models/not_on_update_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe NotOnUpdate, type: :model do
     it "captures changes when in_after_callback is true" do
       record.name = "test"
       record.paper_trail.save_with_version(in_after_callback: true)
-      as_stored_in_version = HashWithIndifferentAccess[
-        YAML.load(record.versions.last.object_changes)
-      ]
-      expect(as_stored_in_version[:name].last).to(eq("test"))
+      changeset = record.versions.last.changeset
+      expect(changeset[:name]).to eq([nil, "test"])
     end
   end
 end


### PR DESCRIPTION
My application calls `PaperTrail::RecordTrail#save_with_version` in an `after` callback. The version record that this method creates does not record the current changes on the object being tracked. I found the cause in the `PaperTrail::Events::Base#load_changes_in_latest_version` method, which only uses `@record.saved_changes` when `@in_after_callback` is true. Unfortunately I don't currently see a way to make `@in_after_callback == true` when using `save_with_version`.

This pull request adds an `in_after_callback` argument to the `PaperTrail::RecordTrail#save_with_version` method, to allow the caller to indicate if this method is being called during an `after` callback. The argument defaults to `false` when not provided.

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] ~~Squashed related commits together.~~
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/