### PR TITLE
Try to create a version record when associated object is touched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1376](https://github.com/paper-trail-gem/paper_trail/pull/1376) -
+  Create a version record when associated object was changed the same as
+  PaperTrail < v12.1.0.
 
 ## 12.2.0 (2022-01-21)
 

--- a/lib/paper_trail/events/update.rb
+++ b/lib/paper_trail/events/update.rb
@@ -40,6 +40,20 @@ module PaperTrail
         merge_metadata_into(data)
       end
 
+      # If it is a touch event, and changed are empty, it is assumed to be
+      # implicit `touch` mutation, and will a version is created.
+      #
+      # See https://github.com/rails/rails/commit/dcb825902d79d0f6baba956f7c6ec5767611353e
+      #
+      # @api private
+      def changed_notably?
+        if @is_touch && changes_in_latest_version.empty?
+          true
+        else
+          super
+        end
+      end
+
       private
 
       # @api private

--- a/spec/dummy_app/app/models/order.rb
+++ b/spec/dummy_app/app/models/order.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Order < ActiveRecord::Base
-  belongs_to :customer
+  belongs_to :customer, touch: :touched_at
   has_many :line_items
   has_paper_trail
 end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -267,6 +267,7 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
 
     create_table :customers, force: true do |t|
       t.string :name
+      t.datetime :touched_at, limit: 6
     end
 
     create_table :orders, force: true do |t|

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Order, type: :model, versioning: true do
+  context "when the record destroyed" do
+    it "creates a version record for association" do
+      customer = Customer.create!
+      described_class.create!(customer: customer)
+      described_class.destroy_all
+
+      expect(customer.versions.count).to(eq(3))
+    end
+  end
+end


### PR DESCRIPTION
Before #1285, a version record was created when associated object is touched.
But because of Rails don't track implicit touch mutation[1], now PaperTail don't create a version record was created when associated object is touched.

This patch try to keep creating a version record in that case by doing checking an event and changed value.

Fixes #1339.

[1]: https://github.com/rails/rails/commit/dcb825902d79d0f6baba956f7c6ec5767611353e

---

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
