### PR TITLE
Fix: n+1 when loading a changeset

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -320,18 +320,10 @@ module PaperTrail
       # and appears to be responsible for custom attribute serializers. For an
       # example of a custom attribute serializer, see
       # `Person::TimeZoneSerializer` in the test suite.
-      #
-      # Is `item.class` good enough? Does it handle `inheritance_column`
-      # as well as `Reifier#version_reification_class`? We were using
-      # `item_type.constantize`, but that is problematic when the STI parent
-      # is not versioned. (See `Vehicle` and `Car` in the test suite).
-      #
-      # Note: `item` returns nil if `event` is "destroy".
-      unless item.nil?
-        AttributeSerializers::ObjectChangesAttribute.
-          new(item.class).
-          deserialize(changes)
-      end
+      type = respond_to?(:item_subtype) ? item_subtype : item_type
+      AttributeSerializers::ObjectChangesAttribute.
+        new(type.constantize).
+        deserialize(changes)
 
       # Finally, return a Hash mapping each attribute name to
       # a two-element array representing before and after.


### PR DESCRIPTION
When producing a changeset, the item is loaded from the database in
order to check it's class. This came about because of issues that
emerged when supporting STI.

Unfortunately, the result is that the record is retrieved once for every
version despite the fact that the item class will be the same.

The documented reason for moving away from using item_type to know the
class was that it returns the wrong class when working with STI but
there is an item_subtype which returns the correct class.

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [N/A] Squashed related commits together.
- [N/A] Added tests.
- [N/A] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.