### PR TITLE
Use standard rubocop conventions

### DIFF
--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -28,11 +28,11 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
       # MySQL users should also upgrade to at least rails 4.2, which is the first
       # version of ActiveRecord with support for fractional seconds in MySQL.
       # (https://github.com/rails/rails/pull/14359)
-      # 
+      #
       # MySQL users should use the following line for `created_at`
-      # t.datetime :created_at, limit: 6                                        
+      # t.datetime :created_at, limit: 6
       t.datetime :created_at
     end
-    add_index :versions, %i(item_type item_id)
+    add_index :versions, %i[item_type item_id]
   end
 end


### PR DESCRIPTION
* remove trailing whitespace
* %i delimiters use square brackets

When I ran rubocop in my project, the following warnings popped up
```
db/migrate/20220227060245_create_versions.rb:31:8: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
      # 
       ^
db/migrate/20220227060245_create_versions.rb:33:41: C: [Correctable] Layout/TrailingWhitespace: Trailing whitespace detected.
      # t.datetime :created_at, limit: 6                                        
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
db/migrate/20220227060245_create_versions.rb:36:26: C: [Correctable] Style/PercentLiteralDelimiters: %i-literals should be delimited by [ and ].
    add_index :versions, %i(item_type item_id)
                         ^^^^^^^^^^^^^^^^^^^^^
```

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
