### PR TITLE
Fix invalid version created_at value when using update_columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1395](https://github.com/paper-trail-gem/paper_trail/issues/1395) Fix invalid
+  `Version#created_at` value when using `PaperTrail::RecordTrail#update_columns`
 
 ## 12.3.0 (2022-03-13)
 

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -148,11 +148,14 @@ module PaperTrail
     # paper_trail-association_tracking
     def record_update_columns(changes)
       return unless enabled?
-      event = Events::Update.new(@record, false, false, changes)
+      data = Events::Update.new(@record, false, false, changes).data
+
+      # use AR default timestamp value instead of record.updated_at value
+      data.delete(:created_at)
 
       # Merge data from `Event` with data from PT-AT. We no longer use
       # `data_for_update_columns` but PT-AT still does.
-      data = event.data.merge(data_for_update_columns)
+      data.merge!(data_for_update_columns)
 
       versions_assoc = @record.send(@record.class.versions_association_name)
       version = versions_assoc.create(data)

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -955,15 +955,19 @@ RSpec.describe Widget, type: :model, versioning: true do
   end
 
   describe ".paper_trail.update_columns", versioning: true do
-    let(:widget) { described_class.create! name: "Bob", an_integer: 1 }
-
     it "creates a version record" do
-      widget = described_class.create
+      widget = described_class.create(updated_at: "2015-01-01 15:00")
       expect(widget.versions.count).to eq(1)
-      widget.paper_trail.update_columns(name: "Bugle")
+      now = nil
+      freeze_time do
+        now = Time.zone.now
+        widget.paper_trail.update_columns(name: "Bugle")
+      end
+
       expect(widget.versions.count).to eq(2)
       expect(widget.versions.last.event).to(eq("update"))
       expect(widget.versions.last.changeset[:name]).to eq([nil, "Bugle"])
+      expect(widget.versions.last.created_at.to_i).to eq(now.to_i)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ end
 SimpleCov.minimum_coverage(ENV["DB"] == "postgres" ? 97.3 : 92.4)
 
 require "byebug"
+require "active_support/testing/time_helpers"
 require_relative "support/pt_arel_helpers"
 
 unless ENV["BUNDLE_GEMFILE"].match?(/rails_\d\.\d\.gemfile/)
@@ -41,6 +42,7 @@ RSpec.configure do |config|
   end
   config.order = :random
   config.include PTArelHelpers
+  config.include ActiveSupport::Testing::TimeHelpers
   Kernel.srand config.seed
 end
 


### PR DESCRIPTION
Use the default(AR generated) timestamp for the `Version#created_at` value when using `PaperTrail::RecordTrail#update_columns`.

`PaperTrail::RecordTrail#update_columns` was previously setting `Version#created_at` as the recod `updated_at` value.
Since `update_columns` does not update timestamps - the previous update date was being used for the `Version#created_at` instead of the actual update date.

Fixes #1395

---------

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
