### PR TITLE
explicitly require active_record

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# Rails 7 (and Rails 6 with Zeitwerk) requires explicit loading of AR.
+require "active_record"
+
 # AR does not require all of AS, but PT does. PT uses core_ext like
 # `String#squish`, so we require `active_support/all`. Instead of eagerly
 # loading all of AS here, we could put specific `require`s in only the various


### PR DESCRIPTION
Rails 7 (and Rails 6 in `zeitwerk` mode) requires active_record to be explicitly required, before the `::ActiveRecord` module becomes available.

I ran into this when using sidekiq-ent's `sidekiqswarm`, which loads the bundle via `Bundler.require(:default)` *before* booting Rails.

Additional context:
* https://github.com/mperham/sidekiq/issues/4766
* https://github.com/mperham/sidekiq/wiki/Ent-Multi-Process#bundler-preload

Note that I did _not_ write any tests for this; I'm not immediately sure what the right way to test this _is_. :)

---

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
