### PR TITLE
Simplify Events::Update by moving the timestamp-copying feature up the stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - [#1399](https://github.com/paper-trail-gem/paper_trail/pull/1399) - Same
   change re: `YAML.safe_load` as in 13.0.0, but this time for Rails 6.0 and 6.1.
+- Certain [Metadata](https://github.com/paper-trail-gem/paper_trail#4c-storing-metadata)
+  keys are now forbidden, like `id`, and `item_type`. These keys are reserved
+  by PT.
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 - [#1399](https://github.com/paper-trail-gem/paper_trail/pull/1399) - Same
   change re: `YAML.safe_load` as in 13.0.0, but this time for Rails 6.0 and 6.1.
-- Certain [Metadata](https://github.com/paper-trail-gem/paper_trail#4c-storing-metadata)
-  keys are now forbidden, like `id`, and `item_type`. These keys are reserved
-  by PT.
+- [#1406](https://github.com/paper-trail-gem/paper_trail/pull/1406) -
+  Certain [Metadata][1] keys are now forbidden, like `id`, and `item_type`.
+  These keys are reserved by PT.
 
 ### Dependencies
 
@@ -1385,3 +1385,5 @@ in the `PaperTrail::Version` class through a `Rails::Engine` when the gem is use
   - [#160](https://github.com/paper-trail-gem/paper_trail/pull/160) - Fixed failing tests and resolved out of date dependency issues.
   - [#157](https://github.com/paper-trail-gem/paper_trail/pull/157) - Refactored `class_attribute` names on the `ClassMethods` module
     for names that are not obviously pertaining to PaperTrail to prevent method name collision.
+
+[1]: https://github.com/paper-trail-gem/paper_trail#4c-storing-metadata

--- a/README.md
+++ b/README.md
@@ -1040,13 +1040,19 @@ PaperTrail::Version.where(author_id: author_id)
 inserted into its own columns.
 
 | *PT Column*    | *How bad of an idea?* | *Alternative*                 |
-| -------------- | --------------------- | ----------------------------- |
-| item_type      | terrible idea         |                               |
-| item_id        | terrible idea         |                               |
+|----------------|-----------------------|-------------------------------|
+| created_at     | forbidden*            |                               |
 | event          | meh                   | paper_trail_event             |
-| whodunnit      | meh                   | PaperTrail.request.whodunnit= |
+| id             | forbidden             |                               |
+| item_id        | forbidden             |                               |
+| item_subtype   | forbidden             |                               |
+| item_type      | forbidden             |                               |
 | object         | a little dangerous    |                               |
 | object_changes | a little dangerous    |                               |
+| updated_at     | forbidden             |                               |
+| whodunnit      | meh                   | PaperTrail.request.whodunnit= |
+
+\* forbidden - raises a `PaperTrail::InvalidOption` error as of PT 14
 
 ## 5. ActiveRecord
 

--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -22,6 +22,19 @@ module PaperTrail
     #
     # @api private
     class Base
+      E_FORBIDDEN_METADATA_KEY = <<-EOS.squish
+        Forbidden metadata key: %s. As of PT 14, the following metadata keys are
+        forbidden: %s
+      EOS
+      FORBIDDEN_METADATA_KEYS = %i[
+        created_at
+        id
+        item_id
+        item_subtype
+        item_type
+        updated_at
+      ].freeze
+
       # @api private
       def initialize(record, in_after_callback)
         @record = record
@@ -43,6 +56,13 @@ module PaperTrail
       end
 
       private
+
+      # @api private
+      def assert_metadatum_key_is_permitted?(key)
+        return unless FORBIDDEN_METADATA_KEYS.include?(key.to_sym)
+        raise PaperTrail::InvalidOption,
+          format(E_FORBIDDEN_METADATA_KEY, key, FORBIDDEN_METADATA_KEYS)
+      end
 
       # Rails 5.1 changed the API of `ActiveRecord::Dirty`. See
       # https://github.com/paper-trail-gem/paper_trail/pull/899
@@ -175,7 +195,9 @@ module PaperTrail
       #
       # @api private
       def merge_metadata_from_controller_into(data)
-        data.merge(PaperTrail.request.controller_info || {})
+        metadata = PaperTrail.request.controller_info || {}
+        metadata.keys.each { |k| assert_metadatum_key_is_permitted?(k) }
+        data.merge(metadata)
       end
 
       # Updates `data` from the model's `meta` option.
@@ -183,6 +205,7 @@ module PaperTrail
       # @api private
       def merge_metadata_from_model_into(data)
         @record.paper_trail_options[:meta].each do |k, v|
+          assert_metadatum_key_is_permitted?(k)
           data[k] = model_metadatum(v, data[:event])
         end
       end

--- a/lib/paper_trail/events/base.rb
+++ b/lib/paper_trail/events/base.rb
@@ -58,7 +58,7 @@ module PaperTrail
       private
 
       # @api private
-      def assert_metadatum_key_is_permitted?(key)
+      def assert_metadatum_key_is_permitted(key)
         return unless FORBIDDEN_METADATA_KEYS.include?(key.to_sym)
         raise PaperTrail::InvalidOption,
           format(E_FORBIDDEN_METADATA_KEY, key, FORBIDDEN_METADATA_KEYS)
@@ -196,7 +196,7 @@ module PaperTrail
       # @api private
       def merge_metadata_from_controller_into(data)
         metadata = PaperTrail.request.controller_info || {}
-        metadata.keys.each { |k| assert_metadatum_key_is_permitted?(k) }
+        metadata.keys.each { |k| assert_metadatum_key_is_permitted(k) }
         data.merge(metadata)
       end
 
@@ -205,7 +205,7 @@ module PaperTrail
       # @api private
       def merge_metadata_from_model_into(data)
         @record.paper_trail_options[:meta].each do |k, v|
-          assert_metadatum_key_is_permitted?(k)
+          assert_metadatum_key_is_permitted(k)
           data[k] = model_metadatum(v, data[:event])
         end
       end

--- a/lib/paper_trail/events/update.rb
+++ b/lib/paper_trail/events/update.rb
@@ -29,9 +29,6 @@ module PaperTrail
           event: @record.paper_trail_event || "update",
           whodunnit: PaperTrail.request.whodunnit
         }
-        if @record.respond_to?(:updated_at)
-          data[:created_at] = @record.updated_at
-        end
         if record_object?
           data[:object] = recordable_object(@is_touch)
         end


### PR DESCRIPTION
Also, on a related note, forbid certain metadata keys, such as `created_at`. The metadata feature is mainly intended for _new_ columns. Hopefully no one is using these forbidden metadata keys, because that seems .. dangerous. More apropos to this PR, if we support such keys, then moving the timestamp-copying feature out of `Events::Update` might not be possible.