### PR TITLE
Change return value of #save_with_version when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Breaking Changes
 
-- None
+- [#1411](https://github.com/paper-trail-gem/paper_trail/pull/1411) - Change the return
+  value of #save_with_version when PaperTrail is disabled. It now returns the result
+  of calling #save on the model.
 
 ### Added
 

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -150,9 +150,13 @@ module PaperTrail
     # This is an "update" event. That is, we record the same data we would in
     # the case of a normal AR `update`.
     def save_with_version(in_after_callback: false, **options)
-      ::PaperTrail.request(enabled: false) do
-        @record.save(**options)
-      end
+      save_result =
+        ::PaperTrail.request(enabled: false) do
+          @record.save(**options)
+        end
+
+      return save_result unless enabled?
+
       record_update(force: true, in_after_callback: in_after_callback, is_touch: false)
     end
 

--- a/spec/dummy_app/app/models/not_on_update.rb
+++ b/spec/dummy_app/app/models/not_on_update.rb
@@ -3,4 +3,6 @@
 # This model does not record versions when updated.
 class NotOnUpdate < ApplicationRecord
   has_paper_trail on: %i[create destroy]
+
+  validates_presence_of :name
 end

--- a/spec/models/not_on_update_spec.rb
+++ b/spec/models/not_on_update_spec.rb
@@ -3,9 +3,9 @@
 require "spec_helper"
 
 RSpec.describe NotOnUpdate, type: :model do
-  describe "#save_with_version", versioning: true do
-    let!(:record) { described_class.create! }
+  let!(:record) { described_class.create!(name: "Name") }
 
+  describe "#save_with_version", versioning: true do
     it "creates a version, regardless" do
       expect { record.paper_trail.save_with_version }.to change {
         PaperTrail::Version.count
@@ -16,7 +16,18 @@ RSpec.describe NotOnUpdate, type: :model do
       record.name = "test"
       record.paper_trail.save_with_version(in_after_callback: true)
       changeset = record.versions.last.changeset
-      expect(changeset[:name]).to eq([nil, "test"])
+      expect(changeset[:name]).to eq(%w[Name test])
+    end
+  end
+
+  describe "#save_with_version", versioning: false do
+    it "returns result of #save if versioning disabled" do
+      result = record.paper_trail.save_with_version
+      expect(result).to be(true)
+
+      record.name = ""
+      result = record.paper_trail.save_with_version
+      expect(result).to be(false)
     end
   end
 end


### PR DESCRIPTION
This patch changes the return value behavior of #save_with_version to return a boolean if PaperTrail is disabled.

Previously #save_with_version would return `nil` if version tracking is disabled. After applying this commit it will return the result of calling #save on the model.

The main reason for changing this behavior is to be able to react to failing saves when using #save_with_version in our application - for example when saving with invalid data.

--- 

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
