### PR TITLE
Version table will use uuid as primary key type if uuid flag is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
   issue that unencrypted plaintext values are versioned with ActiveRecord
   encryption (since Rails 7) when using JSON serialization on PostgreSQL json
   columns.
+- [#1414](https://github.com/paper-trail-gem/paper_trail/pull/1414) - When
+  generating the migration, the version table will use uuid as primary key type
+  if `--uuid` flag is specified.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -119,19 +119,11 @@ Experts: to install incompatible versions of activerecord, see
 1. Add a `versions` table to your database:
 
     ```
-    bundle exec rails generate paper_trail:install [--with-changes]
-    ```
-    
-    If tables in your project use `uuid` instead of `integers` for `id`, then use:  
-    ```
-    bundle exec rails generate paper_trail:install [--uuid]
+    bundle exec rails generate paper_trail:install [--with-changes] [--uuid]
+    bundle exec rails db:migrate
     ```
 
     See [section 5.c. Generators](#5c-generators) for details.
-
-    ```
-    bundle exec rake db:migrate
-    ```
 
 1. Add `has_paper_trail` to the models you want to track.
 

--- a/lib/generators/paper_trail/install/install_generator.rb
+++ b/lib/generators/paper_trail/install/install_generator.rb
@@ -35,7 +35,8 @@ module PaperTrail
         "create_versions",
         item_type_options: item_type_options,
         versions_table_options: versions_table_options,
-        item_id_type_options: item_id_type_options
+        item_id_type_options: item_id_type_options,
+        version_table_primary_key_type: version_table_primary_key_type
       )
       if options.with_changes?
         add_paper_trail_migration("add_object_changes_to_versions")
@@ -47,6 +48,15 @@ module PaperTrail
     # To use uuid instead of integer for primary key
     def item_id_type_options
       options.uuid? ? "string" : "bigint"
+    end
+
+    # To use uuid for version table primary key
+    def version_table_primary_key_type
+      if options.uuid?
+        ", id: :uuid"
+      else
+        ""
+      end
     end
 
     # MySQL 5.6 utf8mb4 limit is 191 chars for keys used in indexes.

--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -9,7 +9,7 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
   TEXT_BYTES = 1_073_741_823
 
   def change
-    create_table :versions<%= versions_table_options %> do |t|
+    create_table :versions<%= versions_table_options %><%= version_table_primary_key_type %> do |t|
       t.string   :item_type<%= item_type_options %>
       t.<%= item_id_type_options %>   :item_id,   null: false
       t.string   :event,     null: false

--- a/spec/generators/paper_trail/install_generator_spec.rb
+++ b/spec/generators/paper_trail/install_generator_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
       run_generator %w[--uuid]
     end
 
-    it "generates a migration for creating the 'versions' table with item_id type uuid" do
+    it "generates a migration for creating the 'versions' table with item_id type string" do
       expected_item_id_type = "string"
       expect(destination_root).to(
         have_structure {
@@ -117,6 +117,21 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
             directory("migrate") {
               migration("create_versions") {
                 contains "t.#{expected_item_id_type}   :item_id,   null: false"
+              }
+            }
+          }
+        }
+      )
+    end
+
+    it "generates a migration for creating the 'versions' table with primary key as uuid type" do
+      expected_primary_key_type = "uuid"
+      expect(destination_root).to(
+        have_structure {
+          directory("db") {
+            directory("migrate") {
+              migration("create_versions") {
+                contains ", id: :#{expected_primary_key_type}"
               }
             }
           }


### PR DESCRIPTION
Version table will use uuid as primary key type if uuid flag is specified on migration generation

Fix for #1402

followup to https://github.com/paper-trail-gem/paper_trail/pull/1374

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
