### PR TITLE
Allow to set --json while generating migration

### DIFF
--- a/lib/generators/paper_trail/install/install_generator.rb
+++ b/lib/generators/paper_trail/install/install_generator.rb
@@ -26,6 +26,12 @@ module PaperTrail
       default: false,
       desc: "Use uuid instead of bigint for item_id type (use only if tables use UUIDs)"
     )
+    class_option(
+      :json,
+      type: :boolean,
+      default: false,
+      desc: "Use json instead of text for object column (use only if database supports json)"
+    )
 
     desc "Generates (but does not run) a migration to add a versions table." \
          "  See section 5.c. Generators in README.md for more information."
@@ -47,6 +53,11 @@ module PaperTrail
     # To use uuid instead of integer for primary key
     def item_id_type_options
       options.uuid? ? "string" : "bigint"
+    end
+
+    # To use uuid instead of integer for primary key
+    def object_column_type
+      options.json? ? "json" : "text"
     end
 
     # MySQL 5.6 utf8mb4 limit is 191 chars for keys used in indexes.

--- a/lib/generators/paper_trail/install/templates/add_object_changes_to_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/add_object_changes_to_versions.rb.erb
@@ -7,6 +7,6 @@ class AddObjectChangesToVersions < ActiveRecord::Migration<%= migration_version 
   TEXT_BYTES = 1_073_741_823
 
   def change
-    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+    add_column :versions, :object_changes, :<%= object_column_type %>, limit: TEXT_BYTES
   end
 end

--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -14,7 +14,7 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
       t.<%= item_id_type_options %>   :item_id,   null: false
       t.string   :event,     null: false
       t.string   :whodunnit
-      t.text     :object, limit: TEXT_BYTES
+      t.<%= object_column_type %>     :object, limit: TEXT_BYTES
 
       # Known issue in MySQL: fractional second precision
       # -------------------------------------------------

--- a/spec/generators/paper_trail/install_generator_spec.rb
+++ b/spec/generators/paper_trail/install_generator_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
       run_generator %w[--with-changes --json]
     end
 
+    # rubocop:disable Layout/LineLength
     it "generates a migration for adding the 'object_changes' column to the 'versions' table with type json" do
       expect(destination_root).to(
         have_structure {
@@ -168,5 +169,6 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
         }
       )
     end
+    # rubocop:enable Layout/LineLength
   end
 end

--- a/spec/generators/paper_trail/install_generator_spec.rb
+++ b/spec/generators/paper_trail/install_generator_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
                 contains "def change"
                 contains "create_table :versions#{expected_create_table_options}"
                 contains "  t.string   :item_type#{expected_item_type_options}"
+                contains "  t.text     :object, limit: TEXT_BYTES"
               }
             }
           }
@@ -117,6 +118,50 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
             directory("migrate") {
               migration("create_versions") {
                 contains "t.#{expected_item_id_type}   :item_id,   null: false"
+              }
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe "`--json` option set to `true`" do
+    before do
+      prepare_destination
+      run_generator %w[--json]
+    end
+
+    it "generates a migration for creating the 'versions' table with `object` type json" do
+      expect(destination_root).to(
+        have_structure {
+          directory("db") {
+            directory("migrate") {
+              migration("create_versions") {
+                contains "t.json     :object, limit: TEXT_BYTES"
+              }
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe "`--with-changes` and `--json` option set to `true`" do
+    before do
+      prepare_destination
+      run_generator %w[--with-changes --json]
+    end
+
+    it "generates a migration for adding the 'object_changes' column to the 'versions' table with type json" do
+      expect(destination_root).to(
+        have_structure {
+          directory("db") {
+            directory("migrate") {
+              migration("add_object_changes_to_versions") {
+                contains "class AddObjectChangesToVersions"
+                contains "def change"
+                contains "add_column :versions, :object_changes, :json"
               }
             }
           }


### PR DESCRIPTION
Starting with PaperTrail 13 json is the preferred `object` and `object_changes` column type, but it needs to be changed manually after the migration has been generated. This is not ideal for ie. engines generating the migration during their install process or if you install paper_trail via an CI.

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
