### PR TITLE
Add model option for not synchronizing timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- [#1416](https://github.com/paper-trail-gem/paper_trail/pull/1416) - Adds a
+  model-configurable option `synchronize_version_creation_timestamp` which, if
+  set to false, opts out of synchronizing timestamps between `Version.created_at`
+  and the record's `updated_at`.
 
 ### Fixed
 

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -53,6 +53,10 @@ module PaperTrail
       #   - A Hash - options passed to `has_many`, plus `name:` and `scope:`.
       # - :version - The name to use for the method which returns the version
       #   the instance was reified from. Default is `:version`.
+      # - :synchronize_version_creation_timestamp - By default, paper trail
+      #   sets the `created_at` field for a new Version equal to the `updated_at`
+      #   column of the model being updated. If you instead want `created_at` to
+      #   populate with the current timestamp, set this option to `false`.
       #
       # Plugins like the experimental `paper_trail-association_tracking` gem
       # may accept additional options.

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -226,7 +226,8 @@ module PaperTrail
       # unnatural to tamper with creation timestamps in this way. But, this
       # feature has existed for a long time, almost a decade now, and some users
       # may rely on it now.
-      if @record.respond_to?(:updated_at)
+      if @record.respond_to?(:updated_at) &&
+          @record.paper_trail_options[:synchronize_version_creation_timestamp] != false
         data[:created_at] = @record.updated_at
       end
 

--- a/spec/dummy_app/app/models/gizmo.rb
+++ b/spec/dummy_app/app/models/gizmo.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Gizmo < ApplicationRecord
+  has_paper_trail synchronize_version_creation_timestamp: false
+end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -48,6 +48,11 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.timestamps null: true, limit: 6
     end
 
+    create_table :gizmos, force: true do |t|
+      t.string :name
+      t.timestamps null: true, limit: 6
+    end
+
     create_table :widgets, force: true do |t|
       t.string    :name
       t.text      :a_text

--- a/spec/models/gizmo_spec.rb
+++ b/spec/models/gizmo_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "support/performance_helpers"
+
+RSpec.describe Gizmo, type: :model, versioning: true do
+  context "with a persisted record" do
+    it "does not use the gizmo `updated_at` as the version's `created_at`" do
+      gizmo = described_class.create(name: "Fred", created_at: Time.current - 1.day)
+      gizmo.name = "Allen"
+      gizmo.save(touch: false)
+      expect(gizmo.versions.last.created_at).not_to(eq(gizmo.updated_at))
+    end
+  end
+end


### PR DESCRIPTION
Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/

Message:
Paper trail automatically synchronizes the version
created_at timestamp to be the same as the updated_at
timestamp of the record being updated. This pull-requests
adds a configurable model-level option to disable this
behavior and instead have created_at be populated with
the timestamp when the version was inserted into the database.

The default remains to synchronize version timestamps

Fixes https://github.com/paper-trail-gem/paper_trail/issues/1377
