### PR TITLE
Fix the issue that unencrypted plaintext values are versioned with ActiveRecord encryption (since Rails 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1422](https://github.com/paper-trail-gem/paper_trail/pull/1422) - Fix the
+  issue that unencrypted plaintext values are versioned with ActiveRecord
+  encryption (since Rails 7) when using JSON serialization on PostgreSQL json
+  columns.
 
 ## 14.0.0 (2022-11-26)
 

--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -114,6 +114,10 @@ module PaperTrail
     def version
       VERSION::STRING
     end
+
+    def active_record_gte_7_0?
+      @active_record_gte_7_0 ||= ::ActiveRecord.gem_version >= ::Gem::Version.new("7.0.0")
+    end
   end
 end
 

--- a/lib/paper_trail/attribute_serializers/cast_attribute_serializer.rb
+++ b/lib/paper_trail/attribute_serializers/cast_attribute_serializer.rb
@@ -32,7 +32,7 @@ module PaperTrail
         if defined_enums[attr] && val.is_a?(::String)
           # Because PT 4 used to save the string version of enums to `object_changes`
           val
-        elsif rails_gte_7_0? && val.is_a?(ActiveRecord::Type::Time::Value)
+        elsif PaperTrail.active_record_gte_7_0? && val.is_a?(ActiveRecord::Type::Time::Value)
           # Because Rails 7 time attribute throws a delegation error when you deserialize
           # it with the factory.
           # See ActiveRecord::Type::Time::Value crashes when loaded from YAML on rails 7.0
@@ -41,10 +41,6 @@ module PaperTrail
         else
           AttributeSerializerFactory.for(@klass, attr).deserialize(val)
         end
-      end
-
-      def rails_gte_7_0?
-        ::ActiveRecord.gem_version >= ::Gem::Version.new("7.0.0")
       end
 
       def serialize(attr, val)

--- a/spec/dummy_app/app/models/fruit.rb
+++ b/spec/dummy_app/app/models/fruit.rb
@@ -5,4 +5,8 @@ class Fruit < ApplicationRecord
   if ENV["DB"] == "postgres"
     has_paper_trail versions: { class_name: "JsonVersion" }
   end
+
+  if PaperTrail.active_record_gte_7_0?
+    encrypts :supplier
+  end
 end

--- a/spec/dummy_app/app/models/vegetable.rb
+++ b/spec/dummy_app/app/models/vegetable.rb
@@ -5,4 +5,8 @@ class Vegetable < ApplicationRecord
   has_paper_trail versions: {
     class_name: ENV["DB"] == "postgres" ? "JsonbVersion" : "PaperTrail::Version"
   }, on: %i[create update]
+
+  if PaperTrail.active_record_gte_7_0?
+    encrypts :supplier
+  end
 end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -290,6 +290,7 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.string :color
       t.integer :mass
       t.string :name
+      t.text :supplier
     end
 
     create_table :boolits, force: true do |t|
@@ -374,6 +375,7 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.string :color
       t.integer :mass
       t.string :name
+      t.text :supplier
     end
   end
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "support/shared_examples/queries"
+require "support/shared_examples/active_record_encryption"
 
 module PaperTrail
   ::RSpec.describe Version, type: :model do
@@ -121,6 +122,8 @@ module PaperTrail
           ::Fruit, # uses JsonVersion
           :mass
         )
+
+        include_examples("active_record_encryption", ::Fruit)
       end
 
       context "with jsonb columns", versioning: true do
@@ -130,6 +133,8 @@ module PaperTrail
           ::Vegetable, # uses JsonbVersion
           :mass
         )
+
+        include_examples("active_record_encryption", ::Vegetable)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require "simplecov"
 SimpleCov.start do
   add_filter %w[Appraisals Gemfile Rakefile doc gemfiles spec]
 end
-SimpleCov.minimum_coverage(ENV["DB"] == "postgres" ? 96.8 : 92.4)
+SimpleCov.minimum_coverage(ENV["DB"] == "postgres" ? 96.79 : 92.4)
 
 require "byebug"
 require_relative "support/pt_arel_helpers"

--- a/spec/support/shared_examples/active_record_encryption.rb
+++ b/spec/support/shared_examples/active_record_encryption.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "active_record_encryption" do |model|
+  if PaperTrail.active_record_gte_7_0?
+    context "when ActiveRecord Encryption is enabled", versioning: true do
+      let(:record) { model.create(supplier: "ABC", name: "Tomato") }
+
+      before do
+        ActiveRecord::Encryption.configure(
+          primary_key: "test",
+          deterministic_key: "test",
+          key_derivation_salt: "test"
+        )
+      end
+
+      it "is versioned with encrypted values" do
+        original_supplier, original_name = record.values_at(:supplier, :name)
+
+        # supplier is encrypted, name is not
+        record.update!(supplier: "XYZ", name: "Avocado")
+
+        expect(record.versions.count).to be 2
+        expect(record.versions.pluck(:event)).to include("create", "update")
+
+        # versioned encrypted value should be something like
+        # "{\"p\":\"zDQU\",\"h\":{\"iv\":\"h2OADmJT3DfK1EZc\",\"at\":\"Urcd0mGSwyu9rGT1vrE5cg==\"}}"
+
+        # check paper trail object
+        object = record.versions.last.object
+        expect(object.to_s).not_to include("XYZ")
+        versioned_supplier, versioned_name = object.values_at("supplier", "name")
+        # encrypted column should be versioned with encrypted value
+        expect(versioned_supplier).not_to eq(original_supplier)
+        # non-encrypted column should be versioned with the original value
+        expect(versioned_name).to eq(original_name)
+        parsed_versioned_supplier = JSON.parse(versioned_supplier)
+        expect(parsed_versioned_supplier)
+          .to match(hash_including("p", "h" => hash_including("iv", "at")))
+
+        # check paper trail object_changes
+        object_changes = record.versions.last.object_changes
+        expect(object_changes.to_s).not_to include("XYZ")
+        supplier_changes, name_changes = object_changes.values_at("supplier", "name")
+        expect(supplier_changes).not_to eq([original_supplier, "XYZ"])
+        expect(name_changes).to eq([original_name, "Avocado"])
+        supplier_changes.each do |supplier|
+          parsed_supplier = JSON.parse(supplier)
+          expect(parsed_supplier).to match(hash_including("p", "h" => hash_including("iv", "at")))
+        end
+      end
+
+      it "reifies encrypted values to decrypted values" do
+        record.update!(supplier: "XYZ", name: "Avocado")
+        expect(record.versions.last.reify.supplier).to eq "ABC"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since Rails 7, ActiveRecord introduces a built-in encryption mechanism. When versioning encrypted attributes for JSON columns on PostgreSQL, currently the unencrypted values are saved. This makes the encryption meaningless, and stops people from upgrading to Rails 7. 

This PR is mainly from the patch that @vccoffey posted at https://github.com/paper-trail-gem/paper_trail/issues/1392#issuecomment-1326737082. Thanks for the original idea.

Fixes #1392.

Check the following boxes:

- [ ] Wrote [good commit messages][1].
- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
