### PR TITLE
Use polymorphic_name on destroy event

### DIFF
--- a/lib/paper_trail/events/destroy.rb
+++ b/lib/paper_trail/events/destroy.rb
@@ -14,7 +14,7 @@ module PaperTrail
       def data
         data = {
           item_id: @record.id,
-          item_type: @record.class.base_class.name,
+          item_type: @record.class.base_class.polymorphic_name,
           event: @record.paper_trail_event || "destroy",
           whodunnit: PaperTrail.request.whodunnit
         }


### PR DESCRIPTION
In Rails it's common to override the polymorphic names used in polymorphic associations. The item association implemented by paper-trail is a polymorphic association and so should use polymorphic methods.

Destroy event is creating versions of types without considering their polymorphic_name but its base name.

Thank you for your contribution!

Check the following boxes:

- [X] Wrote [good commit messages][1].
- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
