### PR TITLE
Removes an unnecessary query when checking version limit config.

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -385,7 +385,7 @@ module PaperTrail
     #
     # @api private
     def version_limit
-      klass = item.class
+      klass = (item_subtype || item_type).constantize
       if limit_option?(klass)
         klass.paper_trail_options[:limit]
       elsif base_class_limit_option?(klass)


### PR DESCRIPTION
- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests. (N/A)
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes. (N/A)
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

Due to some monkey patching adding an `on_view` feature in an application I am working on, this query resulted in an infinite loop in our specific case. As this query is unnecessary I thought I'd try to get a slight performance improvement in for the whole project and be able to remove some monkeypatching code from my project's codebase.

I'd also add, this extra query seems to be a result of some upstream change in Rails. I wasn't able to identify the actual source of it in Rails, but this query started happening between version 12 and version 13 of PaperTrail.

If there's anything else I need to add (tests or Changelog entry) or change, let me know and I'll follow up.