### PR TITLE
Add config to enable storing the object after the update

### DIFF
--- a/lib/paper_trail.rb
+++ b/lib/paper_trail.rb
@@ -100,6 +100,18 @@ module PaperTrail
       PaperTrail.config.serializer
     end
 
+    # Set the storage method for storing the object after change instead of before change
+    # @api public
+    def store_after_change=(value)
+      PaperTrail.config.store_after_change= value
+    end
+
+    # Get the storage method: storage before or after applying the changes
+    # @api public
+    def store_after_change
+      PaperTrail.config.store_after_change
+    end
+
     # Returns PaperTrail's global configuration object, a singleton. These
     # settings affect all threads.
     # @api public

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -13,6 +13,7 @@ module PaperTrail
       :association_reify_error_behaviour,
       :object_changes_adapter,
       :serializer,
+      :store_after_change,
       :version_limit,
       :has_paper_trail_defaults
     )
@@ -24,6 +25,7 @@ module PaperTrail
 
       # Variables which affect all threads, whose access is *not* synchronized.
       @serializer = PaperTrail::Serializers::YAML
+      @store_after_change = false
       @has_paper_trail_defaults = {}
     end
 

--- a/lib/paper_trail/events/create.rb
+++ b/lib/paper_trail/events/create.rb
@@ -20,6 +20,9 @@ module PaperTrail
         if @record.respond_to?(:updated_at)
           data[:created_at] = @record.updated_at
         end
+        if record_object? && PaperTrail.config.store_after_change
+          data[:object] = recordable_object(false)
+        end
         if record_object_changes? && changed_notably?
           changes = notable_changes
           data[:object_changes] = prepare_object_changes(changes)


### PR DESCRIPTION
I recently started implementing paper-trail in our project, and was pleasantly surprised with the provided features.

But one thing struck me as odd:

> PaperTrail stores the pre-change version of the model, unlike some other auditing/versioning plugins, so you can retrieve the original version. [1](https://github.com/paper-trail-gem/paper_trail/tree/master#1c-basic-usage)

Indeed, when using other audit systems, it's usually the new version that gets saved. And for certain reasons IMO:
* When displaying the versions in a UI, it also makes more sense to show the result of what the user inputted next to who made the change when, thus it also belongs in the same record IMO
* For all non-destroyed records, all version's objects will be non-nil
* The original version is just `widget.versions.first.reify`, a lot more logical than `widget.versions.second&.reify || widget`
* The last version equals the current state. This also means if something happens and doesn't get logged (like an accidental delete directly in the database), you can still restore the most recent version.

As for the main advantage: tracking objects that existed before, that's also possible by writing a migration and touching all the objects you want to track. Or perhaps even write a bulk-insert migration directly to the database.

I didn't want to change the default behaviour, as apparently a lot of people happily use it with the current working. So I chose to add a separate configuration to switch between both ways of working.

I didn't write tests or documentation yet, if you'd like to add this configuration, I'd be happy to write that too.

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
