### PR TITLE
Fix typo in spec/spec_helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,7 +79,7 @@ require File.expand_path("dummy_app/config/environment", __dir__)
 require_relative "support/paper_trail_spec_migrator"
 ::PaperTrailSpecMigrator.new.migrate
 
-# This final section reselmbles what might be dummy_app's spec_helper, if it
+# This final section resembles what might be dummy_app's spec_helper, if it
 # had one.
 require "paper_trail/frameworks/rspec"
 RSpec.configure do |config|


### PR DESCRIPTION
Hi, folks!
Just fixed typo in the comments on `spec/spec_helper.rb`