### PR TITLE
Provide option to disable association touch versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ## Unreleased
 
+- Provide option to disable association touch versions
+
 ### Breaking Changes
 
 - None

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Global configuration options affect all threads.
 - object_changes_adapter
 - serializer
 - version_limit
+- association_touch_versions
 
 Syntax example: (options described in detail later)
 
@@ -305,6 +306,16 @@ These options are intended to be set only once, during app initialization (eg.
 in `config/initializers`). It is unsafe to change them while the app is running.
 In contrast, `PaperTrail.request` has various options that only apply to a
 single HTTP request and thus are safe to use while the app is running.
+
+##### Association touch versions
+By default if you have an ActiveRecord association with `touch: true` then a new version will be created on the association with an empty object changeset.  This will happen regardless of if you have ignore or skip set on the updated attribute.  Thus this setting allows you to disable the version creation triggered by associations with `touch: true`.
+
+To disable set to false:
+```ruby
+PaperTrail.config.association_touch_versions = false
+```
+
+For more details see: https://github.com/paper-trail-gem/paper_trail/pull/1376
 
 ## 2. Limiting What is Versioned, and When
 

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -14,7 +14,8 @@ module PaperTrail
       :object_changes_adapter,
       :serializer,
       :version_limit,
-      :has_paper_trail_defaults
+      :has_paper_trail_defaults,
+      :association_touch_versions
     )
 
     def initialize
@@ -25,6 +26,7 @@ module PaperTrail
       # Variables which affect all threads, whose access is *not* synchronized.
       @serializer = PaperTrail::Serializers::YAML
       @has_paper_trail_defaults = {}
+      @association_touch_versions = true
     end
 
     # Indicates whether PaperTrail is on or off. Default: true.

--- a/lib/paper_trail/events/update.rb
+++ b/lib/paper_trail/events/update.rb
@@ -44,7 +44,8 @@ module PaperTrail
       #
       # @api private
       def changed_notably?
-        if @is_touch && changes_in_latest_version.empty?
+        if @is_touch && changes_in_latest_version.empty? \
+            && PaperTrail.config.association_touch_versions
           true
         else
           super

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -12,4 +12,20 @@ RSpec.describe Order, type: :model, versioning: true do
       expect(customer.versions.count).to(eq(3))
     end
   end
+
+  context "when option: association_touch_versions is set false" do
+    around do |example|
+      PaperTrail.config.association_touch_versions = false
+      example.run
+      PaperTrail.config.association_touch_versions = true
+    end
+
+    it "does not create a version record for association" do
+      customer = Customer.create!
+      order = described_class.create!(customer_id: customer.id)
+      order.reload.update(order_date: Time.now.getlocal)
+
+      expect(customer.versions.count).to(eq(1))
+    end
+  end
 end


### PR DESCRIPTION
Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/

This PR provides an option to disable association change versions (w/ empty object changes), which currently does not adhere to ignore/skip options.  Related to previous patch: https://github.com/paper-trail-gem/paper_trail/pull/1376