### PR TITLE
Drop `RequestStore` in favour of `ActiveSupport::CurrentAttributes`

### DIFF
--- a/lib/paper_trail/frameworks/rails/railtie.rb
+++ b/lib/paper_trail/frameworks/rails/railtie.rb
@@ -26,5 +26,12 @@ module PaperTrail
         require "paper_trail/frameworks/active_record"
       end
     end
+
+    # ActiveSupport::CurrentAttributes resets all attributes before and after each request.
+    # Resetting after a request breaks backwards compatibility with the previous RequestStore
+    # implementation. This initializer ensures this reset is skipped.
+    initializer "active_support.reset_all_current_attributes_instances" do |app|
+      app.executor.to_run { PaperTrail::Request::CurrentAttributes.skip_reset = true }
+    end
   end
 end

--- a/lib/paper_trail/request/current_attributes.rb
+++ b/lib/paper_trail/request/current_attributes.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module PaperTrail
+  module Request
+    # Thread-isolated attributes for managing the current request.
+    class CurrentAttributes < ActiveSupport::CurrentAttributes
+      attribute :enabled
+      attribute :enabled_for
+      attribute :controller_info
+      attribute :whodunnit
+      attribute :skip_reset
+
+      def enabled_for
+        super || self.enabled_for = {}
+      end
+
+      def controller_info
+        super || self.controller_info = {}
+      end
+
+      # Overrides ActiveSupport::CurrentAttributes#reset to support skipping.
+      def reset
+        return if skip_reset
+        super
+      end
+    end
+  end
+end

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -49,9 +49,6 @@ has been destroyed.
   # See discussion in paper_trail/compatibility.rb
   s.add_dependency "activerecord", ::PaperTrail::Compatibility::ACTIVERECORD_GTE
 
-  # PT supports request_store versions for 3 years.
-  s.add_dependency "request_store", "~> 1.4"
-
   s.add_development_dependency "appraisal", "~> 2.4.1"
   s.add_development_dependency "byebug", "~> 11.1"
   s.add_development_dependency "ffaker", "~> 2.20"

--- a/spec/controllers/widgets_controller_spec.rb
+++ b/spec/controllers/widgets_controller_spec.rb
@@ -5,8 +5,6 @@ require "spec_helper"
 RSpec.describe WidgetsController, type: :controller, versioning: true do
   before { request.env["REMOTE_ADDR"] = "127.0.0.1" }
 
-  after { RequestStore.store[:paper_trail] = nil }
-
   describe "#create" do
     context "with PT enabled" do
       it "stores information like IP address in version" do

--- a/spec/paper_trail/request/current_attributes_spec.rb
+++ b/spec/paper_trail/request/current_attributes_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module PaperTrail
+  module Request
+    ::RSpec.describe CurrentAttributes.new do
+      describe ".enabled_for" do
+        context "when enabled_for is nil" do
+          it "sets enabled_for to an empty hash to and returns it" do
+            expect(described_class.attributes[:enabled_for]).to be_nil
+            expect(described_class.enabled_for).to eq({})
+            expect(described_class.attributes[:enabled_for]).to eq({})
+          end
+        end
+      end
+
+      describe ".controller_info" do
+        context "when controller_info is nil" do
+          it "sets controller_info to an empty hash to and returns it" do
+            expect(described_class.attributes[:controller_info]).to be_nil
+            expect(described_class.controller_info).to eq({})
+            expect(described_class.attributes[:controller_info]).to eq({})
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/

Fixes https://github.com/paper-trail-gem/paper_trail/issues/1444

I wonder if there are any performance benefits here, I'm happy to run some benchmarks if it's a valid concern.