### PR TITLE
Add version_error_behavior config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- [#1422](https://github.com/paper-trail-gem/paper_trail/pull/1450) - Add `always_raise_on_error`
-  config option to consistently surface errors when creating `Version` records.
+- [#1422](https://github.com/paper-trail-gem/paper_trail/pull/1450) - Add `version_error_behavior` config
+  config option to control error handling when creating/updating/deleting `Version` records.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- [#1422](https://github.com/paper-trail-gem/paper_trail/pull/1450) - Add `always_raise_on_error`
+  config option to consistently surface errors when creating `Version` records.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Global configuration options affect all threads.
 - object_changes_adapter
 - serializer
 - version_limit
+- always_raise_on_error
 
 Syntax example: (options described in detail later)
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Global configuration options affect all threads.
 - object_changes_adapter
 - serializer
 - version_limit
-- always_raise_on_error
+- version_error_behavior
 
 Syntax example: (options described in detail later)
 

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -14,7 +14,8 @@ module PaperTrail
       :object_changes_adapter,
       :serializer,
       :version_limit,
-      :has_paper_trail_defaults
+      :has_paper_trail_defaults,
+      :always_raise_on_error
     )
 
     def initialize

--- a/lib/paper_trail/config.rb
+++ b/lib/paper_trail/config.rb
@@ -15,7 +15,7 @@ module PaperTrail
       :serializer,
       :version_limit,
       :has_paper_trail_defaults,
-      :always_raise_on_error
+      :version_error_behavior
     )
 
     def initialize
@@ -26,6 +26,7 @@ module PaperTrail
       # Variables which affect all threads, whose access is *not* synchronized.
       @serializer = PaperTrail::Serializers::YAML
       @has_paper_trail_defaults = {}
+      @version_error_behavior = :legacy
     end
 
     # Indicates whether PaperTrail is on or off. Default: true.

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -72,7 +72,6 @@ module PaperTrail
     # @api private
     # @return - The created version object, so that plugins can use it, e.g.
     # paper_trail-association_tracking
-    # rubocop:disable Metrics/AbcSize
     def record_destroy(recording_order)
       return unless enabled? && !@record.new_record?
       in_after_callback = recording_order == "after"
@@ -88,14 +87,9 @@ module PaperTrail
         assign_and_reset_version_association(version)
         version
       rescue StandardError => e
-        if PaperTrail.config.always_raise_on_error
-          raise e
-        else
-          log_version_errors(version, :destroy)
-        end
+        handle_version_errors e, version, :destroy
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     # @api private
     # @param force [boolean] Insert a `Version` even if `@record` has not
@@ -123,11 +117,7 @@ module PaperTrail
         versions.reset
         version
       rescue StandardError => e
-        if PaperTrail.config.always_raise_on_error
-          raise e
-        else
-          log_version_errors(version, :update)
-        end
+        handle_version_errors e, version, :update
       end
     end
 
@@ -298,6 +288,16 @@ module PaperTrail
       )
     end
 
+    # Centralized handler for version errors
+    # @api private
+    def handle_version_errors(e, version, action)
+      if PaperTrail.config.always_raise_on_error
+        raise e
+      else
+        log_version_errors(version, action)
+      end
+    end
+
     # @api private
     # @return - The created version object, so that plugins can use it, e.g.
     # paper_trail-association_tracking
@@ -315,11 +315,7 @@ module PaperTrail
         version.save!
         version
       rescue StandardError => e
-        if PaperTrail.config.always_raise_on_error
-          raise e
-        else
-          log_version_errors(version, :update)
-        end
+        handle_version_errors e, version, :update
       end
     end
 

--- a/lib/paper_trail/record_trail.rb
+++ b/lib/paper_trail/record_trail.rb
@@ -72,6 +72,7 @@ module PaperTrail
     # @api private
     # @return - The created version object, so that plugins can use it, e.g.
     # paper_trail-association_tracking
+    # rubocop:disable Metrics/AbcSize
     def record_destroy(recording_order)
       return unless enabled? && !@record.new_record?
       in_after_callback = recording_order == "after"
@@ -94,6 +95,7 @@ module PaperTrail
         end
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     # @api private
     # @param force [boolean] Insert a `Version` even if `@record` has not

--- a/spec/dummy_app/app/models/comment.rb
+++ b/spec/dummy_app/app/models/comment.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  has_paper_trail versions: { class_name: "CommentVersion" }
+end

--- a/spec/dummy_app/app/versions/comment_version.rb
+++ b/spec/dummy_app/app/versions/comment_version.rb
@@ -2,4 +2,6 @@
 
 class CommentVersion < PaperTrail::Version
   self.table_name = "comment_versions"
+  # add rails validation to require whodunnit
+  validates :whodunnit, presence: true
 end

--- a/spec/dummy_app/app/versions/comment_version.rb
+++ b/spec/dummy_app/app/versions/comment_version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CommentVersion < PaperTrail::Version
+  self.table_name = "comment_versions"
+end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -114,6 +114,17 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
     end
     add_index :post_versions, %i[item_type item_id]
 
+    # Requires whodunnit column.
+    create_table :comment_versions, force: true do |t|
+      t.string   :item_type, null: false
+      t.integer  :item_id,   null: false
+      t.string   :event,     null: false
+      t.string   :whodunnit, null: false
+      t.text     :object
+      t.datetime :created_at, limit: 6
+    end
+    add_index :comment_versions, %i[item_type item_id]
+
     # Uses custom versions table `no_object_versions`.
     create_table :no_objects, force: true do |t|
       t.string :letter, null: false, limit: 1
@@ -221,6 +232,10 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
 
     create_table :posts, force: true do |t|
       t.string :title
+      t.string :content
+    end
+
+    create_table :comments, force: true do |t|
       t.string :content
     end
 

--- a/spec/paper_trail/config_spec.rb
+++ b/spec/paper_trail/config_spec.rb
@@ -27,7 +27,7 @@ module PaperTrail
           it "raises an error on create" do
             expect {
               Comment.create!(content: "Henry")
-            }.to raise_error(ActiveRecord::NotNullViolation)
+            }.to raise_error(ActiveRecord::RecordInvalid)
           end
 
           it "raises an error on update" do
@@ -37,7 +37,7 @@ module PaperTrail
 
             expect {
               comment.update!(content: "Brad")
-            }.to raise_error(ActiveRecord::NotNullViolation)
+            }.to raise_error(ActiveRecord::RecordInvalid)
           end
 
           it "raises an error on update_columns" do
@@ -57,7 +57,7 @@ module PaperTrail
 
             expect {
               comment.destroy!
-            }.to raise_error(ActiveRecord::NotNullViolation)
+            }.to raise_error(ActiveRecord::RecordInvalid)
           end
         end
       end
@@ -69,7 +69,7 @@ module PaperTrail
           it "raises an error on create" do
             expect {
               Comment.create!(content: "Henry")
-            }.to raise_error(ActiveRecord::NotNullViolation)
+            }.to raise_error(ActiveRecord::RecordInvalid)
           end
 
           it "does not raise an error on update" do

--- a/spec/paper_trail/config_spec.rb
+++ b/spec/paper_trail/config_spec.rb
@@ -17,6 +17,94 @@ module PaperTrail
       end
     end
 
+    describe ".always_raise_on_error", versioning: true do
+      context "when true" do
+        context "when version cannot be created" do
+          before { PaperTrail.config.always_raise_on_error = true }
+
+          after { PaperTrail.config.always_raise_on_error = false }
+
+          it "raises an error on create" do
+            expect {
+              Comment.create!(content: "Henry")
+            }.to raise_error(ActiveRecord::NotNullViolation)
+          end
+
+          it "raises an error on update" do
+            comment = PaperTrail.request(whodunnit: "Foo") do
+              Comment.create!(content: "Henry")
+            end
+
+            expect {
+              comment.update!(content: "Brad")
+            }.to raise_error(ActiveRecord::NotNullViolation)
+          end
+
+          it "raises an error on update_columns" do
+            comment = PaperTrail.request(whodunnit: "Foo") do
+              Comment.create!(content: "Henry")
+            end
+
+            expect {
+              comment.update_columns(content: "Brad")
+            }.not_to raise_error
+          end
+
+          it "raises an error on destroy" do
+            comment = PaperTrail.request(whodunnit: "Foo") do
+              Comment.create!(content: "Henry")
+            end
+
+            expect {
+              comment.destroy!
+            }.to raise_error(ActiveRecord::NotNullViolation)
+          end
+        end
+      end
+
+      context "when false" do
+        context "when version cannot be created" do
+          before { PaperTrail.config.always_raise_on_error = false }
+
+          it "raises an error on create" do
+            expect {
+              Comment.create!(content: "Henry")
+            }.to raise_error(ActiveRecord::NotNullViolation)
+          end
+
+          it "does not raise an error on update" do
+            comment = PaperTrail.request(whodunnit: "Foo") do
+              Comment.create!(content: "Henry")
+            end
+
+            expect {
+              comment.update!(content: "Brad")
+            }.not_to raise_error
+          end
+
+          it "does not raise an error on update_columns" do
+            comment = PaperTrail.request(whodunnit: "Foo") do
+              Comment.create!(content: "Henry")
+            end
+
+            expect {
+              comment.update_columns(content: "Brad")
+            }.not_to raise_error
+          end
+
+          it "does not raises an error on destroy" do
+            comment = PaperTrail.request(whodunnit: "Foo") do
+              Comment.create!(content: "Henry")
+            end
+
+            expect {
+              comment.destroy!
+            }.not_to raise_error
+          end
+        end
+      end
+    end
+
     describe ".version_limit", versioning: true do
       after { PaperTrail.config.version_limit = nil }
 


### PR DESCRIPTION
NOTE: all the specs pass locally but rubocop is failing on a complexity check - i'm unsure exactly how to simplify this code  to satisfy rubocop without making the intent less clear. happy to hear suggestions? for now i've disabled the check around the offending method

Currently when creating a new versioned record an error is raised if the `Version` cannot be created - this is because `#save!` is used:

https://github.com/paper-trail-gem/paper_trail/blob/47dbc2271c7055fde6f0fe7d3c8bf44f62cbef63/lib/paper_trail/record_trail.rb#L62

However, when updating, using `update_columns`, or destroying a versioned record no error is raised if the `Version` cannot be created:

https://github.com/paper-trail-gem/paper_trail/blob/47dbc2271c7055fde6f0fe7d3c8bf44f62cbef63/lib/paper_trail/record_trail.rb#L111

https://github.com/paper-trail-gem/paper_trail/blob/47dbc2271c7055fde6f0fe7d3c8bf44f62cbef63/lib/paper_trail/record_trail.rb#L301

https://github.com/paper-trail-gem/paper_trail/blob/47dbc2271c7055fde6f0fe7d3c8bf44f62cbef63/lib/paper_trail/record_trail.rb#L84

This pr adds a `always_raise_on_error` global config option. When set, all of the above failures will raise an error. 

Fixes #1449 

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
