### PR TITLE
Fix error logging in `object_changes_deserialized`

### DIFF
--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -355,7 +355,7 @@ module PaperTrail
         begin
           PaperTrail.serializer.load(object_changes)
         rescue StandardError => e
-          if defined?(::Psych::Exception) && e.instance_of?(::Psych::Exception)
+          if defined?(::Psych::Exception) && e.is_a?(::Psych::Exception)
             ::Kernel.warn format(E_YAML_PERMITTED_CLASSES, e)
           end
           {}


### PR DESCRIPTION
I was trying to debug some code that was throwing a:

```
Psych::DisallowedClass: Tried to load unspecified class: Time
```

This warning was not being printed, because `Psych::DisallowedClass` is a subclass of `Psych::Exception`. So I think you want to use `is_a?`, not `instance_of?`.


- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
