### PR TITLE
Suggest using numeric `whodunnit` column type for performance

### DIFF
--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -10,6 +10,8 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
 
   def change
     create_table :versions<%= versions_table_options %><%= version_table_primary_key_type %> do |t|
+      # Consider using bigint type for performance if you are going to store only numeric ids.
+      # t.bigint   :whodunnit
       t.string   :whodunnit
 
       # Known issue in MySQL: fractional second precision


### PR DESCRIPTION
We are currently using paper_trail and have billions of items in the `versions` table and the table is huge. 
One of the easy improvements that could have been done back then was using numeric type for `whodunnit` column. We currently plan to switch to `integer` which is 4 bytes, while using strings to store integer values can easily require much more space, like for `1000000` it will require 8 bytes (padding included), so twice the space. And also integers have statis types, which is easier for databases to work with.

So, I think it is a good idea at least to suggest people to consider switching to numeric types in the migration's comment.

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
