### PR TITLE
Change `versions` table layout for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- Change `versions` table layout for performance
 
 ### Fixed
 

--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -10,11 +10,7 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
 
   def change
     create_table :versions<%= versions_table_options %><%= version_table_primary_key_type %> do |t|
-      t.string   :item_type<%= item_type_options %>
-      t.<%= item_id_type_options %>   :item_id,   null: false
-      t.string   :event,     null: false
       t.string   :whodunnit
-      t.text     :object, limit: TEXT_BYTES
 
       # Known issue in MySQL: fractional second precision
       # -------------------------------------------------
@@ -32,6 +28,11 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
       # MySQL users should use the following line for `created_at`
       # t.datetime :created_at, limit: 6
       t.datetime :created_at
+
+      t.<%= item_id_type_options %>   :item_id,   null: false
+      t.string   :item_type<%= item_type_options %>
+      t.string   :event,     null: false
+      t.text     :object, limit: TEXT_BYTES
     end
     add_index :versions, %i[item_type item_id]
   end


### PR DESCRIPTION
We are currently using paper_trail and have billions of items in the `versions` table and the table is huge. 

The one easy improvement I noticed is the `versions` table layout. Currently, its layout is not optimal and will cause unnecessary fragmentation inside the table. There are good articles on the theme like [one](https://www.2ndquadrant.com/en/blog/on-rocks-and-sand/) and [two](https://stackoverflow.com/questions/2966524/calculating-and-saving-space-in-postgresql/7431468#7431468). Basically, we need to have fields with static sizes first in the table packed in a way to reduce paddings.

With the currently implemented layout, if we consider that the user decides to use `bigint` for `whodunnit` (see https://github.com/paper-trail-gem/paper_trail/pull/1456), then `whodunnit`, `item_id` and `created_at` should be positioned on 8 bytes boundaries (because each of them have 8 bytes in size) and the fields that precede them can have a padding added at the end for this to happen. This can be as much as 7 bytes of padding for each field.

For example, if we have 4 billions of records in the database and each row has a 21 byte of wasteful padding, then we can save `4 * 10^9 * 21 / 10^9` ~ 100Gb 🔥 of memory by just doing this simple table layout change.

Also, afaik, postgres precalculates padding for columns in the row for statically sized columns (for prefix of the columns with static types) and than can easily jump to specific columns using that offsets when reading the row. Instead of manually traversing the row with dynamic column sizes to get to the needed column. So, this will also speedup the reading of `whodunnit`, `item_id` and `created_at` columns. 

I believe, this will improve the situation for MySQL too.

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
