### PR TITLE
Fix serializing of time/date columns using yaml serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1458](https://github.com/paper-trail-gem/paper_trail/pull/1416) - Fix serializing
+  date/time columns using yaml serializer. Previously, these were serialized as ruby
+  objects which use a lot of space. Now they are serialized into strings.
 
 ## 15.1.0 (2023-10-22)
 

--- a/lib/paper_trail/attribute_serializers/attribute_serializer_factory.rb
+++ b/lib/paper_trail/attribute_serializers/attribute_serializer_factory.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "paper_trail/type_serializers/date_time_serializer"
 require "paper_trail/type_serializers/postgres_array_serializer"
 
 module PaperTrail
@@ -20,12 +21,21 @@ module PaperTrail
               active_record_serializer.subtype,
               active_record_serializer.delimiter
             )
+          elsif ar_date_time?(active_record_serializer)
+            TypeSerializers::DateTimeSerializer.new(active_record_serializer)
           else
             active_record_serializer
           end
         end
 
         private
+
+        DATE_TIME_TYPES = %i[timestamp timestamptz datetime date time].freeze
+        private_constant :DATE_TIME_TYPES
+
+        def ar_date_time?(obj)
+          DATE_TIME_TYPES.include?(obj.type)
+        end
 
         # @api private
         def ar_pg_array?(obj)

--- a/lib/paper_trail/type_serializers/date_time_serializer.rb
+++ b/lib/paper_trail/type_serializers/date_time_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module PaperTrail
+  module TypeSerializers
+    # Provides an alternative method of serialization
+    # and deserialization of date related columns.
+    class DateTimeSerializer
+      def initialize(original_type)
+        @original_type = original_type
+      end
+
+      def serialize(value)
+        value&.to_json
+      end
+
+      def deserialize(value)
+        @original_type.deserialize(value)
+      end
+    end
+  end
+end

--- a/spec/paper_trail/attribute_serializers/object_attribute_spec.rb
+++ b/spec/paper_trail/attribute_serializers/object_attribute_spec.rb
@@ -40,6 +40,27 @@ module PaperTrail
           end
         end
       end
+
+      describe "#serialize" do
+        it "serializes a time object into a plain string" do
+          time = Time.zone.local(2015, 7, 15, 20, 34, 0)
+          attrs = { "created_at" => time }
+          described_class.new(Widget).serialize(attrs)
+          expect(attrs["created_at"]).not_to be_a(ActiveSupport::TimeWithZone)
+          expect(attrs["created_at"]).to be_a(String)
+          expect(attrs["created_at"]).to match(/2015/)
+        end
+      end
+
+      describe "#deserialize" do
+        it "deserializes a time object correctly" do
+          time = 1.day.ago
+          attrs = { "created_at" => time }
+          described_class.new(Widget).serialize(attrs)
+          described_class.new(Widget).deserialize(attrs)
+          expect(attrs["created_at"].to_i).to eq(time.to_i)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
We are currently using paper_trail and have billions of items in the `versions` table and the table is huge. 

I noticed, that for yaml serializer date/time objects are serialized as ruby objects. Something like
```yml
--- !ruby/object:ActiveSupport::TimeWithZone
utc: 2024-01-27 18:01:54.627764000 Z
zone: !ruby/object:ActiveSupport::TimeZone
  name: Etc/UTC
time: 2024-01-27 18:01:54.627764000 Z
```

This generates 179 bytes per field.

But that should be serialized into the string. Something like
```yml
--- 2024-01-27 18:03:07 UTC
```

That is 28 bytes long, so 150 bytes difference.

Considering that most people have at least 2 datetime columns (`created_at` and `updated_at`) for each table, that saves 300 bytes per row in the table. 
For example, if we have a table with 4 billion rows, that is `4 * 10^9 * 300 / 10^9` = 1200 GB 😱 saved.

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
