### PR TITLE
Fixes Rails 7.1 raise_on_assign_to_attr_readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1467](https://github.com/paper-trail-gem/paper_trail/issues/1467) - Rails 7.1
+  enables ActiveRecord.raise_on_assign_to_attr_readonly so that writing to a
+  attr_readonly raises an exception. Fixes paper trail to gracefully handle this
+  situation.
 
 ### Dependencies
 

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -92,7 +92,7 @@ module PaperTrail
       # @api private
       def reify_attribute(k, v, model, version)
         if model.has_attribute?(k)
-          model[k.to_sym] = v
+          model[k.to_sym] = v unless model.class.readonly_attribute?(k.to_s)
         elsif model.respond_to?("#{k}=")
           model.send("#{k}=", v)
         elsif version.logger

--- a/spec/dummy_app/app/models/wotsit.rb
+++ b/spec/dummy_app/app/models/wotsit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Wotsit < ApplicationRecord
+  attr_readonly :id
   has_paper_trail
 
   belongs_to :widget, optional: true

--- a/spec/models/wotsit_spec.rb
+++ b/spec/models/wotsit_spec.rb
@@ -3,12 +3,39 @@
 require "spec_helper"
 
 RSpec.describe Wotsit, versioning: true do
-  it "update! records timestamps" do
-    wotsit = described_class.create!(name: "wotsit")
-    wotsit.update!(name: "changed")
-    reified = wotsit.versions.last.reify
-    expect(reified.created_at).not_to(be_nil)
-    expect(reified.updated_at).not_to(be_nil)
+  context "when handling attr_readonly attributes" do
+    context "without raise_on_assign_to_attr_readonly" do
+      before do
+        # Rails 7.1 first introduces this setting, and framework_defaults 7.0 has it as false
+        if ActiveRecord.respond_to?(:raise_on_assign_to_attr_readonly)
+          ActiveRecord.raise_on_assign_to_attr_readonly = false
+        end
+      end
+
+      it "update! records timestamps" do
+        wotsit = described_class.create!(name: "wotsit")
+        wotsit.update!(name: "changed")
+        reified = wotsit.versions.last.reify
+        expect(reified.created_at).not_to(be_nil)
+        expect(reified.updated_at).not_to(be_nil)
+      end
+    end
+
+    if ActiveRecord.respond_to?(:raise_on_assign_to_attr_readonly)
+      context "with raise_on_assign_to_attr_readonly enabled" do
+        before do
+          ActiveRecord.raise_on_assign_to_attr_readonly = true
+        end
+
+        it "update! records timestamps" do
+          wotsit = described_class.create!(name: "wotsit")
+          wotsit.update!(name: "changed")
+          reified = wotsit.versions.last.reify
+          expect(reified.created_at).not_to(be_nil)
+          expect(reified.updated_at).not_to(be_nil)
+        end
+      end
+    end
   end
 
   it "update! does not raise error" do


### PR DESCRIPTION
Fixes #1467

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/

I manually tested this PR with these commands:
```
DB=sqlite  bundle exec appraisal rails-7.1 rspec /Users/todd.sedano/workspace/paper_trail/spec/models/wotsit_spec.rb
DB=sqlite  bundle exec appraisal rails-7.0 rspec /Users/todd.sedano/workspace/paper_trail/spec/models/wotsit_spec.rb
DB=sqlite  bundle exec appraisal rails-6.1 rspec /Users/todd.sedano/workspace/paper_trail/spec/models/wotsit_spec.rb
```