### PR TITLE
Only set the attribute value in reify when it's different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1473](https://github.com/paper-trail-gem/paper_trail/pull/1473) - Only set the attribute value in `reify` when it's different. This potentially prevents default readonly attributes from being set again, and aligns with Rails 7.1's new config default `raise_on_assign_to_attr_readonly`.
 
 ## 15.1.0 (2023-10-22)
 

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -92,7 +92,7 @@ module PaperTrail
       # @api private
       def reify_attribute(k, v, model, version)
         if model.has_attribute?(k)
-          model[k.to_sym] = v
+          model[k.to_sym] = v unless model.attributes[k] == v
         elsif model.respond_to?("#{k}=")
           model.send("#{k}=", v)
         elsif version.logger


### PR DESCRIPTION
- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/

This is related to https://github.com/paper-trail-gem/paper_trail/pull/1468/files#r1601766553

We shouldn't set something again if the value is no difference from the original value. In some cases such like read only attributes might already set with a default value and will not change over time, this is helpful and will not violate Rails 7.1's new default config `raise_on_assign_to_attr_readonly`.
