### PR TITLE
Do not allow multiple `has_paper_trail` definitions for models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Breaking Changes
 
-- None
+- [#1478](https://github.com/paper-trail-gem/paper_trail/issues/1478) Do not allow
+  multiple `has_paper_trail` definitions for models. Previously, when `has_paper_trail`
+  was called on a parent and a child from STI, then possibly multiple `version` records
+  will be created per event (`create`, `destroy` etc).
 
 ### Added
 

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -68,6 +68,8 @@ module PaperTrail
       #
       # @api public
       def has_paper_trail(options = {})
+        raise Error, "has_paper_trail must be called only once" if self < InstanceMethods
+
         defaults = PaperTrail.config.has_paper_trail_defaults
         paper_trail.setup(defaults.merge(options))
       end

--- a/spec/dummy_app/app/models/callback_modifier.rb
+++ b/spec/dummy_app/app/models/callback_modifier.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-class CallbackModifier < ApplicationRecord
-  has_paper_trail on: []
+module CallbackModifier
+  extend ActiveSupport::Concern
+
+  included do
+    self.table_name = "callback_modifiers"
+  end
 
   def test_destroy
     transaction do
@@ -17,33 +21,45 @@ class CallbackModifier < ApplicationRecord
   end
 end
 
-class BeforeDestroyModifier < CallbackModifier
+class BeforeDestroyModifier < ApplicationRecord
+  include CallbackModifier
+
   has_paper_trail on: []
   paper_trail.on_destroy :before
 end
 
 unless ActiveRecord::Base.belongs_to_required_by_default
-  class AfterDestroyModifier < CallbackModifier
+  class AfterDestroyModifier < ApplicationRecord
+    include CallbackModifier
+
     has_paper_trail on: []
     paper_trail.on_destroy :after
   end
 end
 
-class NoArgDestroyModifier < CallbackModifier
+class NoArgDestroyModifier < ApplicationRecord
+  include CallbackModifier
+
   has_paper_trail on: []
   paper_trail.on_destroy
 end
 
-class UpdateModifier < CallbackModifier
+class UpdateModifier < ApplicationRecord
+  include CallbackModifier
+
   has_paper_trail on: []
   paper_trail.on_update
 end
 
-class CreateModifier < CallbackModifier
+class CreateModifier < ApplicationRecord
+  include CallbackModifier
+
   has_paper_trail on: []
   paper_trail.on_create
 end
 
-class DefaultModifier < CallbackModifier
+class DefaultModifier < ApplicationRecord
+  include CallbackModifier
+
   has_paper_trail
 end

--- a/spec/paper_trail/model_config_spec.rb
+++ b/spec/paper_trail/model_config_spec.rb
@@ -5,6 +5,16 @@ require "spec_helper"
 module PaperTrail
   ::RSpec.describe ModelConfig do
     describe "has_paper_trail" do
+      it "raises when called multiple times" do
+        klass = Class.new(ApplicationRecord) do
+          has_paper_trail
+        end
+
+        expect do
+          klass.has_paper_trail
+        end.to raise_error(Error, "has_paper_trail must be called only once")
+      end
+
       describe "versions:" do
         it "name can be passed instead of an options hash", :deprecated do
           allow(::ActiveSupport::Deprecation).to receive(:warn)


### PR DESCRIPTION
Fixes #1478.

There were 3 variants on how to proceed:
1. ignore multiple `has_paper_trail` calls - this can be confusing, for example
```ruby
class Parent < ApplicationRecord
  has_paper_trail on: [:create]
end

class Child < Parent
  has_paper_trail on: [:update]
end
```
For which events we should create `version` records? 🤷 Same without STI (just when we include some module and have the `has_paper_trail` called on the class) or just `has_paper_trail` defined on the `ApplicationRecord` and then in the concrete class too.

2. detect if we use STI and do something smart about it (as suggested in the issue) - this won't work, because when we detect that we use STI, the callbacks are already defined on the parent model and we can't "undefine" them
3. raise if we have multiple calls - implemented in this PR. Looks the most sane to me, but this is a breaking change