### PR TITLE
Support for belongs_to whodunnit

### DIFF
--- a/lib/paper_trail/request.rb
+++ b/lib/paper_trail/request.rb
@@ -80,7 +80,7 @@ module PaperTrail
       def with(options)
         return unless block_given?
         validate_public_options(options)
-        before = to_h
+        before = store.dup
         merge(options)
         yield
       ensure
@@ -130,15 +130,6 @@ module PaperTrail
         RequestStore.store[:paper_trail] ||= {
           enabled: true
         }
-      end
-
-      # Returns a deep copy of the internal hash from our RequestStore. Keys are
-      # all symbols. Values are mostly primitives, but whodunnit can be a Proc.
-      # We cannot use Marshal.dump here because it doesn't support Proc. It is
-      # unclear exactly how `deep_dup` handles a Proc, but it doesn't complain.
-      # @api private
-      def to_h
-        store.deep_dup
       end
 
       # Provide a helpful error message if someone has a typo in one of their

--- a/spec/dummy_app/app/models/planet.rb
+++ b/spec/dummy_app/app/models/planet.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Planet < ApplicationRecord
+  has_paper_trail versions: { class_name: "PlanetVersion" }
+end

--- a/spec/dummy_app/app/models/user.rb
+++ b/spec/dummy_app/app/models/user.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+end

--- a/spec/dummy_app/app/versions/planet_version.rb
+++ b/spec/dummy_app/app/versions/planet_version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PlanetVersion < PaperTrail::Version
+  self.table_name = :planet_versions
+
+  belongs_to :whodunnit, class_name: "User", optional: true
+end

--- a/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb
@@ -67,6 +67,25 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.timestamps null: true, limit: 6
     end
 
+    create_table :users, force: true do |t|
+      t.string :name, null: false
+      t.timestamps null: true, limit: 6
+    end
+
+    create_table :planets, force: true do |t|
+      t.string :name, null: false
+      t.timestamps null: true, limit: 6
+    end
+
+    create_table :planet_versions, force: true do |t|
+      t.string     :item_type, null: false
+      t.integer    :item_id,   null: false
+      t.string     :event,     null: false
+      t.references :whodunnit, null: true, foreign_key: { to_table: :users }
+      t.text       :object
+      t.datetime   :created_at, limit: 6
+    end
+
     if ENV["DB"] == "postgres"
       create_table :postgres_users, force: true do |t|
         t.string     :name

--- a/spec/models/planet_spec.rb
+++ b/spec/models/planet_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Planet, type: :model do
+  let!(:user) { User.create!(name: FFaker::Name.name) }
+
+  def create_and_update_planet
+    PaperTrail.request(whodunnit: user) do
+      planet = PaperTrail.request(whodunnit: nil) do
+        Planet.create!(name: "The Earth")
+      end
+      planet.update!(name: "Earth")
+    end
+  end
+
+  it { expect { create_and_update_planet }.not_to change(User, :count).from(1) }
+end


### PR DESCRIPTION
Thank you really much for PaperTrail.

I ran into a bug while using PaperTrail in a specific way:
- I'm using custom version classes
- I'm using Active Record instances as whodunnit values to enforce foreign keys
  - instead of `t.string :whodunnit` I have `t.references :whodunnit, foreign_key: {to_table: :users}`
  - ```ruby
    class CustomVersion < PaperTrailVersion
      belongs_to :whodunnit, class_name: "User"
    end
    ```

I really loved that this worked out of the box.
But I eventually ran into a weird behavior:
- Given that the current `PaperTrail.request.whodunnit` is an instance of a `User`
- When using `PaperTrail.request(whodunnit:)` with a block
- Then the value set back on `PaperTrail.request.whodunnit` is a dup (new record) of the initial user instance.

This is particularly bad when creating another version right after because that new `User` dup will now be saved and duplicated.

I did my best to add a test to highlight the problem with a new test. I understand that using an AR model as whodunnit value is not necessarily supported, but the proposed changed should not break the API.

Thank you

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] <strike>Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.</strike>
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
