### PR TITLE
Upgrade Appraisal gem to 2.5

### DIFF
--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -56,7 +56,7 @@ has been destroyed.
   # PT supports request_store versions for 3 years.
   s.add_dependency "request_store", "~> 1.4"
 
-  s.add_development_dependency "appraisal", "~> 2.4.1"
+  s.add_development_dependency "appraisal", "~> 2.5"
   s.add_development_dependency "byebug", "~> 11.1"
   s.add_development_dependency "ffaker", "~> 2.20"
   s.add_development_dependency "generator_spec", "~> 0.9.4"


### PR DESCRIPTION
Thank you for your contribution!

Check the following boxes:

- [ X] Wrote [good commit messages][1].
- [ X] Feature branch is up-to-date with `master` (if not - rebase it).
- [ X] Squashed related commits together.
- [ N/A] Added tests.
- [ N/A] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/

For those running Bundler `>= 2.4` and wishing to contribute to this Gem we need to upgrade Appraisal to >2.5 to [resolve an issue](https://github.com/thoughtbot/appraisal/issues/199#issuecomment-1374700828) where `bundle check` command no longer generates a lockfile and so the `bundle exec appraisal install` command fails