### PR TITLE
Rails 8.0.0 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,11 +59,14 @@ jobs:
       # have set this up with each database as a separate job, but then we'd be
       # duplicating the matrix configuration three times.
       matrix:
-        gemfile: [ 'rails_6.1', 'rails_7.0', 'rails_7.1', 'rails_7.2' ]
+        gemfile: [ 'rails_6.1', 'rails_7.0', 'rails_7.1', 'rails_7.2', 'rails_8.0.0.beta' ]
 
         # To keep matrix size down, only test highest and lowest rubies.
         # See "Lowest supported ruby version" in CONTRIBUTING.md
         ruby: [ '3.1', '3.3' ]
+        exclude:
+          - gemfile: rails_8.0.0.beta
+            ruby: '3.1'
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/

# Changes

- Rails 8 drop support of Ruby 3.1, and required at least 3.2