### PR TITLE
Temporarily override reaonly_attribute? method when reify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1467](https://github.com/paper-trail-gem/paper_trail/issues/1467) - Rails 7.1
+  enables ActiveRecord.raise_on_assign_to_attr_readonly so that writing to a
+  attr_readonly raises an exception. Fixes paper trail to allow setting the value
+  of an attr_readonly attribute to the value of the previous version when reifying.
 
 ## 16.0.0 (2024-11-08)
 

--- a/lib/paper_trail/has_paper_trail.rb
+++ b/lib/paper_trail/has_paper_trail.rb
@@ -13,6 +13,7 @@ module PaperTrail
   module Model
     def self.included(base)
       base.extend ClassMethods
+      base.thread_mattr_accessor :_paper_trail_reifying, instance_accessor: false
     end
 
     # :nodoc:
@@ -77,6 +78,12 @@ module PaperTrail
       # @api public
       def paper_trail
         ::PaperTrail::ModelConfig.new(self)
+      end
+
+      def readonly_attribute?(name)
+        return false if _paper_trail_reifying
+
+        super
       end
     end
 

--- a/lib/paper_trail/reifier.rb
+++ b/lib/paper_trail/reifier.rb
@@ -13,7 +13,9 @@ module PaperTrail
         options = apply_defaults_to(options, version)
         attrs = version.object_deserialized
         model = init_model(attrs, options, version)
+        model.class._paper_trail_reifying = true
         reify_attributes(model, version, attrs)
+        model.class._paper_trail_reifying = false
         model.send "#{model.class.version_association_name}=", version
         model
       end

--- a/spec/dummy_app/app/models/wotsit.rb
+++ b/spec/dummy_app/app/models/wotsit.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Wotsit < ApplicationRecord
+  attr_readonly :id
   has_paper_trail
 
   belongs_to :widget, optional: true

--- a/spec/models/wotsit_spec.rb
+++ b/spec/models/wotsit_spec.rb
@@ -3,12 +3,40 @@
 require "spec_helper"
 
 RSpec.describe Wotsit, versioning: true do
-  it "update! records timestamps" do
-    wotsit = described_class.create!(name: "wotsit")
-    wotsit.update!(name: "changed")
-    reified = wotsit.versions.last.reify
-    expect(reified.created_at).not_to(be_nil)
-    expect(reified.updated_at).not_to(be_nil)
+  context "when handling attr_readonly attributes" do
+    context "without raise_on_assign_to_attr_readonly" do
+      before do
+        # Rails 7.1 first introduces this setting, and framework_defaults 7.0 has it as false
+        if ActiveRecord.respond_to?(:raise_on_assign_to_attr_readonly)
+          ActiveRecord.raise_on_assign_to_attr_readonly = false
+        end
+      end
+
+      it "update! records timestamps" do
+        wotsit = described_class.create!(name: "wotsit")
+        wotsit.update!(name: "changed")
+        reified = wotsit.versions.last.reify
+        expect(reified.created_at).not_to(be_nil)
+        expect(reified.updated_at).not_to(be_nil)
+      end
+    end
+
+    if ActiveRecord.respond_to?(:raise_on_assign_to_attr_readonly)
+      context "with raise_on_assign_to_attr_readonly enabled" do
+        before do
+          ActiveRecord.raise_on_assign_to_attr_readonly = true
+        end
+
+        it "update! records timestamps" do
+          wotsit = described_class.create!(name: "wotsit")
+          wotsit.update!(name: "changed")
+          reified = wotsit.versions.last.reify
+          expect(reified.created_at).not_to(be_nil)
+          expect(reified.updated_at).not_to(be_nil)
+          expect(reified.name).to eq("wotsit")
+        end
+      end
+    end
   end
 
   it "update! does not raise error" do


### PR DESCRIPTION
Implements option 1 in [this discussion](https://github.com/paper-trail-gem/paper_trail/pull/1468/files?w=1#r1601766553)

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
