### PR TITLE
Disable strict_loading on the version association

### DIFF
--- a/lib/paper_trail/model_config.rb
+++ b/lib/paper_trail/model_config.rb
@@ -185,6 +185,7 @@ module PaperTrail
         scope,
         class_name: @model_class.version_class_name,
         as: :item,
+        strict_loading: false,
         **options[:versions].except(:name, :scope)
       )
     end


### PR DESCRIPTION
As documented in #222, paper_trail doesn't support eager-loading, which means anyone turning on strict_loading by default:

```ruby
# config/application.rb
config.active_record.strict_loading_by_default = true
config.active_record.strict_loading_mode = :n_plus_one_only
```

Will routinely encounter errors like:

```
ActiveRecord::StrictLoadingViolationError: `Membership` is marked for strict_loading. The ApplicationVersion association named `:versions` cannot be lazily loaded.
```

I'd normally have just configured this on `has_paper_trail_defaults`, but since that only does a `merge` and not a deep-merge (since this is nested under `:versions`), that won't work, and it seems like too much of a foot-gun to expect each and every `has_paper_trail` to remember to set `strict_loading: false` in applications with strict_loading enabled by default
