### PR TITLE
Avoid N+1 queries coming from #version_limit when destroying records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Fixed
 
-- None
+- [#1511](https://github.com/paper-trail-gem/paper_trail/pull/1511) - Avoid N+1
+  queries when destroying a record with a `has_many` `dependent: :destroy`
+  association where the `has_many` target model is tracked by PaperTrail.
 
 ### Dependencies
 

--- a/lib/paper_trail/version_concern.rb
+++ b/lib/paper_trail/version_concern.rb
@@ -385,7 +385,7 @@ module PaperTrail
     #
     # @api private
     def version_limit
-      klass = item.class
+      klass = ((respond_to?(:item_subtype) && item_subtype) || item_type).constantize
       if limit_option?(klass)
         klass.paper_trail_options[:limit]
       elsif base_class_limit_option?(klass)

--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -70,6 +70,7 @@ has been destroyed.
   s.add_development_dependency "ffaker", "~> 2.20"
   s.add_development_dependency "generator_spec", "~> 0.9.4"
   s.add_development_dependency "memory_profiler", "~> 1.0.0"
+  s.add_development_dependency "n_plus_one_control", "~> 0.7.2"
 
   # For `spec/dummy_app`. Technically, we only need `actionpack` (as of 2020).
   # However, that might change in the future, and the advantages of specifying a

--- a/spec/dummy_app/app/versions/post_version.rb
+++ b/spec/dummy_app/app/versions/post_version.rb
@@ -2,4 +2,19 @@
 
 class PostVersion < PaperTrail::Version
   self.table_name = "post_versions"
+
+  # BEGIN Hack to simulate a version class that doesn't have the optional `item_subtype` column. >>>
+  def item_subtype
+    raise "This method should not be called!"
+  end
+
+  # We will follow Ruby's `respond_to?` method signature, including an optional boolean parameter.
+  # rubocop:disable Style/OptionalBooleanParameter
+  def respond_to?(method_name, include_private = false)
+    # rubocop:enable Style/OptionalBooleanParameter
+    return false if method_name.to_sym == :item_subtype
+
+    super
+  end
+  # <<< END Hack to simulate a version class that doesn't have the optional `item_subtype` column.
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -11,5 +11,22 @@ RSpec.describe Order, :versioning do
 
       expect(customer.versions.count).to(eq(3))
     end
+
+    # We need to use an instance variable to work with the `n_plus_one_control` gem in this spec.
+    # rubocop:disable RSpec/InstanceVariable
+    context "when the record has many associated records (N+1 check)", :n_plus_one do
+      populate do |n|
+        @customer = Customer.create!
+
+        n.times do
+          @customer.orders.create!
+        end
+      end
+
+      it "does not cause an N+1 query" do
+        expect { @customer.destroy! }.to perform_constant_number_of_queries
+      end
+    end
+    # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,6 +69,7 @@ require "action_controller/railtie"
 # by the `Bundler.require` in `config/application.rb`.
 require "paper_trail"
 require "ffaker"
+require "n_plus_one_control/rspec"
 require "rspec/rails"
 require "rails-controller-testing"
 


### PR DESCRIPTION
Fixes #1510

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/

## Avoiding N+1 queries when destroying a record with a `has_many` `dependent: :destroy` association

This change avoids N+1 queries that otherwise currently occur on the `master` branch when destroying a record with a `has_many` `dependent: :destroy` association where the `has_many` model is tracked by PaperTrail.

## My thoughts about this PR

Some of the things mentioned below are somewhat questionable/hacky. I understand if a PR in this form isn't really desired. But I believe that this change does fix the bug linked above, and I personally think that the changes herein are beneficial improvements to the gem and to its test suite.

## Background context

I believe that the N+1 queries that this PR aims to remove were introduced by [this change](https://github.com/paper-trail-gem/paper_trail/pull/1309/files#diff-ce609ac9edbdf2df8bfe15246950dce5efa7efac84609883bb7a210bdef3ba39L386), and this current change essentially undoes that specific linked change in #1309 (though this current change handles the fact that `item_subtype` is an optional column in a slightly different way than did the original code prior to that change that I believe introduced this N+1 query).

## Adding `n_plus_one_control` gem

In order to test this change, this PR adds the [`n_plus_one_control` gem](https://github.com/palkan/n_plus_one_control) as a development dependency. I understand that adding dependencies (even development-only dependencies) is a somewhat significant change, and that we might not want to add that gem for the sake of (at least for now) a single test. Nevertheless, it seemed to me like an effective way to test this change, and also that having the `n_plus_one_control` gem available might also be useful to write other specs in the future related to N+1 queries (or, rather, to a lack thereof), and so I'm including that gem in this proposed change.

## Using an instance variable in the spec

I think that the nature of how that gem works (maybe specifically in conjunction with the fact that the spec being added herein destroys the `Customer` record that is somewhat the subject of the spec?) necessitates capturing the `Customer` record with an instance variable, so I disabled the `RSpec/InstanceVariable` cop for that spec.

## Hacking `PostVersion` to act like it has no `item_subtype` method

In working on this change, in one iteration, I wrote code that assumes that the object into which the `PaperTrail::VersionConcern` module has been included will respond to an `item_subtype` message (i.e. have such a method). Specifically, I had written `(item_subtype || item_type).constantize`. Although this code will fail in any project that uses PaperTrail but which does not add an `item_subtype` column for the versions table, all specs nevertheless passed (when executed with `DB=sqlite bundle exec appraisal rails-8.0 rspec`). This implied to me that there is not currently any spec coverage/awareness of the fact that `item_subtype` is an optional column that will not be available in all projects.

I believe that this is the observation that was being made by @jaredbeck [here](https://github.com/paper-trail-gem/paper_trail/pull/1381#issuecomment-1153464553):

> Looking at our SimpleCov report, It seems we are missing a test for when `item_subtype` is _absent_? That seems important because `item_subtype` is an optional column.

The reason that the test suite doesn't have coverage of this possibility (not having an `item_subtype` method) is because all of the version models in the test suite inherit from `PaperTrail::Version`, which, in the spec setup, uses the `versions` table, which is [defined with an `item_subtype` column](https://github.com/paper-trail-gem/paper_trail/blob/94e9c0daa28c5a60441f5e173f3e6b1d2c555918/spec/dummy_app/db/migrate/20110208155312_set_up_test_tables.rb#L82). So all of the version models in the test suite respond to `item_subtype`, even if their respective tables (e.g. `post_versions`) do not have an `item_subtype` column.

This differs from the situation of real applications using `paper_trail`, where in many (most?) of those applications the PaperTrail version model(s) will _not_ respond to an `item_subtype` method.

To try to give the test suite some awareness of this possibility, I hacked one of the version models -- `PostVersion` -- to raise an error if #item_subtype is called and to return `false` when queried with `respond_to?(:item_subtype)`. This is ugly/hacky, but it does at least have the beneficial effect that the problematic iteration of my code change that I mentioned above would be caught by some failing specs.