### PR TITLE
Add as development dependencies gems extracted from Ruby stdlib

### DIFF
--- a/paper_trail.gemspec
+++ b/paper_trail.gemspec
@@ -56,6 +56,14 @@ has been destroyed.
   # PT supports request_store versions for 3 years.
   s.add_dependency "request_store", "~> 1.4"
 
+  # The following gems have been extracted from the Ruby stdlib to gems, and we
+  # must manually include them here in order for specs to run.
+  s.add_development_dependency "benchmark", "~> 0.4.0"
+  s.add_development_dependency "bigdecimal", "~> 3.1"
+  s.add_development_dependency "drb", "~> 2.2"
+  s.add_development_dependency "logger", "~> 1.6"
+  s.add_development_dependency "mutex_m", "~> 0.3.0"
+
   s.add_development_dependency "appraisal", "~> 2.5"
   s.add_development_dependency "byebug", "~> 11.1"
   s.add_development_dependency "ffaker", "~> 2.20"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,7 +60,8 @@ end
 Bundler.setup
 
 # Then, the chosen components of Rails would be loaded. In our case, we only
-# test with AR and AC.
+# test with AR and AC. We require `logger` because `active_record` needs it.
+require "logger"
 require "active_record/railtie"
 require "action_controller/railtie"
 


### PR DESCRIPTION
Specs are currently failing on `master` on my local machine when I try to run specs with `BUNDLE_GEMFILE=/home/david/code/paper_trail/gemfiles/rails_6.1.gemfile bundle exec rspec`. This isn't yet reflected in any CI builds on `master`, but I believe that it would be, if a build were to be triggered on `master`. The same error is also occurring in recent PRs that have been put up (e.g. [this PR][1] with [this failed build][2] and [this PR][3] with [this failed build][4]).

[1]: https://github.com/paper-trail-gem/paper_trail/pull/1509
[2]: https://github.com/paper-trail-gem/paper_trail/actions/runs/13835939334/job/38733099092?pr=1509
[3]: https://github.com/paper-trail-gem/paper_trail/pull/1511
[4]: https://github.com/paper-trail-gem/paper_trail/actions/runs/13916744592/job/38941085149?pr=1511

I'm not sure why these errors have started occurring now, without any changes in `master` since [the last commit on `master`][5] that passed all checks. Maybe `bundler` changed its behavior, and we are pulling in a new/recent version of `bundler` with some relevant behavior change?

[5]: https://github.com/paper-trail-gem/paper_trail/commit/94e9c0daa28c5a60441f5e173f3e6b1d2c555918

But, anyway, the errors seem to be caused by the extraction of various gems from the Ruby standard library into standalone gems, specifically:

1. `bigdecimal`
1. `drb`
1. `mutex_m`

This change adds those gems as development dependencies of `paper_trail`.

Although they are not yet causing errors, the following gems were causing a warning for me when I ran specs using Ruby 3.4.2 with `BUNDLE_GEMFILE=/home/david/code/paper_trail/gemfiles/rails_6.1.gemfile bundle exec rspec`:

1. `benchmark`
1. `logger`

These are the warnings:

> /home/david/code/paper_trail/spec/spec_helper.rb:64: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
> You can add logger to your Gemfile or gemspec to silence this warning.
> /home/david/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-6.1.7.10/lib/active_support/dependencies.rb:299: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
> You can add benchmark to your Gemfile or gemspec to silence this warning.
> Also please contact the author of activesupport-6.1.7.10 to request adding benchmark into its gemspec.

To avoid these warnings, I am also adding these two gems as development dependencies.

Additionally, this change adds a `require "logger"` statement to `spec/spec_helper.rb`. This isn't needed for the other gems (I'm guessing because `activerecord` and/or `actionpack` have `require` statements for `benchmark`, `bigdecimal`, `drb`, `mutex_m`?), but it seems to be needed for `logger`; without it, we get an error when trying to boot specs about `NameError: uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger`.

I think that these changes will get specs passing on `master` again.

---

Thank you for your contribution!

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] ~~Added tests.~~ **N/A:** I _believe_ that tests will fail right now if run on `master`. If tests pass on this branch, that is an indication of success; I don't think that new tests are warranted.
- [ ] ~~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes.~~ **N/A:** This isn't a user-observable change.
- [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/