### PR TITLE
Homogenize effects of synchronize_version_creation_timestamp for create event

### DIFF
--- a/lib/paper_trail/events/create.rb
+++ b/lib/paper_trail/events/create.rb
@@ -17,7 +17,8 @@ module PaperTrail
           event: @record.paper_trail_event || "create",
           whodunnit: PaperTrail.request.whodunnit
         }
-        if @record.respond_to?(:updated_at)
+        if @record.respond_to?(:updated_at) &&
+            @record.paper_trail_options[:synchronize_version_creation_timestamp] != false
           data[:created_at] = @record.updated_at
         end
         if record_object_changes? && changed_notably?

--- a/spec/models/gizmo_spec.rb
+++ b/spec/models/gizmo_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Gizmo, :versioning do
   context "with a persisted record" do
     it "does not use the gizmo `updated_at` as the version's `created_at`" do
       gizmo = described_class.create(name: "Fred", created_at: 1.day.ago)
+      expect(gizmo.versions.last.created_at).not_to(eq(gizmo.updated_at))
+
       gizmo.name = "Allen"
       gizmo.save(touch: false)
       expect(gizmo.versions.last.created_at).not_to(eq(gizmo.updated_at))


### PR DESCRIPTION
Hello,

This is a proposal to homogenize the effects of `synchronize_version_creation_timestamp` used to opt out (value set to `false`) of synchronizing the version timestamp with the record's update_at timestamp.

This would close #1505.