### PR TITLE
Add optional argument for custom version table generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ recommendations of [keepachangelog.com](http://keepachangelog.com/).
 
 ### Added
 
-- None
+- `rails generate paper_trail:install` now accepts an argument for custom versions table, e.g. `rails generate paper_trail:install CommentVersion` created `comment_versions` table
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1154,6 +1154,8 @@ Be advised that redefining an association is an undocumented feature of Rails.
 PaperTrail has one generator, `paper_trail:install`. It writes, but does not
 run, a migration file. The migration creates the `versions` table.
 
+You can provide a custom version table name e.g., for having multiple version tables. You will still need setup a custom Version class and configure it to use the custom table. See [6.a. Custom Version Classes](#6a-custom-version-classes).
+
 #### Reference
 
 The most up-to-date documentation for this generator can be found by running
@@ -1162,19 +1164,25 @@ convenience.
 
 ```
 Usage:
-  rails generate paper_trail:install [options]
+  bin/rails generate paper_trail:install [VERSION_CLASS_NAME] [options]
 
 Options:
-  [--with-changes], [--no-with-changes]            # Store changeset (diff) with each version
-  [--uuid]                                         # To use paper_trail with projects using uuid for id
+  [--skip-namespace]                                            # Skip namespace (affects only isolated engines)
+                                                                # Default: false
+  [--skip-collision-check]                                      # Skip collision check
+                                                                # Default: false
+  [--with-changes], [--no-with-changes], [--skip-with-changes]  # Store changeset (diff) with each version
+                                                                # Default: false
+  [--uuid], [--no-uuid], [--skip-uuid]                          # Use uuid instead of bigint for item_id type (use only if tables use UUIDs)
+                                                                # Default: false
 
 Runtime options:
-  -f, [--force]                    # Overwrite files that already exist
-  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
-  -q, [--quiet], [--no-quiet]      # Suppress status output
-  -s, [--skip], [--no-skip]        # Skip files that already exist
+  -f, [--force]                                      # Overwrite files that already exist
+  -p, [--pretend], [--no-pretend], [--skip-pretend]  # Run but do not make any changes
+  -q, [--quiet], [--no-quiet], [--skip-quiet]        # Suppress status output
+  -s, [--skip], [--no-skip], [--skip-skip]           # Skip files that already exist
 
-Generates (but does not run) a migration to add a versions table.
+Generates (but does not run) a migration to add a versions table. Can be customized by providing a Version class name. See section 5.c. Generators in README.md for more information.
 ```
 
 ### 5.d. Protected Attributes

--- a/lib/generators/paper_trail/install/USAGE
+++ b/lib/generators/paper_trail/install/USAGE
@@ -1,3 +1,31 @@
 Description:
   Generates (but does not run) a migration to add a versions table. Also generates an initializer
-  file for configuring PaperTrail. See section 5.c. Generators in README.md for more information.
+  file for configuring PaperTrail. Can be customized by providing a Version class name.
+  See section 5.c. Generators in README.md for more information.
+
+Examples:
+  rails generate paper_trail:install
+
+  This will create:
+    db/migrate/[TIMESTAMP]_create_versions.rb
+    config/initializers/paper_trail.rb
+
+  rails generate paper_trail:install --with-changes
+
+  This will create:
+    db/migrate/[TIMESTAMP]_create_versions.rb
+    db/migrate/[TIMESTAMP]_add_object_changes_to_versions.rb
+    config/initializers/paper_trail.rb
+
+  rails generate paper_trail:install CommentVersion
+
+  This will create:
+    db/migrate/[TIMESTAMP]_create_comment_versions.rb
+    config/initializers/paper_trail.rb
+
+  rails generate paper_trail:install ProductVersion --with-changes --uuid
+
+  This will create:
+    db/migrate/[TIMESTAMP]_create_product_versions.rb
+    db/migrate/[TIMESTAMP]_add_object_changes_to_product_versions.rb
+    config/initializers/paper_trail.rb

--- a/lib/generators/paper_trail/install/install_generator.rb
+++ b/lib/generators/paper_trail/install/install_generator.rb
@@ -27,19 +27,21 @@ module PaperTrail
       desc: "Use uuid instead of bigint for item_id type (use only if tables use UUIDs)"
     )
 
-    desc "Generates (but does not run) a migration to add a versions table.  " \
-         "See section 5.c. Generators in README.md for more information."
+    desc "Generates (but does not run) a migration to add a versions table. " \
+           "Can be customized by providing a Version class name. " \
+           "See section 5.c. Generators in README.md for more information."
 
     def create_migration_file
+      # Use the table_name to create the proper migration filename
       add_paper_trail_migration(
-        "create_versions",
+        "create_#{table_name}",
         item_type_options: item_type_options,
         versions_table_options: versions_table_options,
         item_id_type_options: item_id_type_options,
         version_table_primary_key_type: version_table_primary_key_type
       )
       if options.with_changes?
-        add_paper_trail_migration("add_object_changes_to_versions")
+        add_paper_trail_migration("add_object_changes_to_#{table_name}")
       end
     end
 

--- a/lib/generators/paper_trail/install/templates/add_object_changes_to_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/add_object_changes_to_versions.rb.erb
@@ -1,12 +1,12 @@
 # This migration adds the optional `object_changes` column, in which PaperTrail
 # will store the `changes` diff for each update event. See the readme for
 # details.
-class AddObjectChangesToVersions < ActiveRecord::Migration<%= migration_version %>
+class AddObjectChangesTo<%= version_class_name.pluralize %> < ActiveRecord::Migration<%= migration_version %>
   # The largest text column available in all supported RDBMS.
   # See `create_versions.rb` for details.
   TEXT_BYTES = 1_073_741_823
 
   def change
-    add_column :versions, :object_changes, :text, limit: TEXT_BYTES
+    add_column :<%= table_name %>, :object_changes, :text, limit: TEXT_BYTES
   end
 end

--- a/lib/generators/paper_trail/install/templates/create_versions.rb.erb
+++ b/lib/generators/paper_trail/install/templates/create_versions.rb.erb
@@ -1,6 +1,6 @@
-# This migration creates the `versions` table, the only schema PT requires.
+# This migration creates the `<%= table_name %>` table for the <%= version_class_name %> class.
 # All other migrations PT provides are optional.
-class CreateVersions < ActiveRecord::Migration<%= migration_version %>
+class Create<%= version_class_name.pluralize %> < ActiveRecord::Migration<%= migration_version %>
 
   # The largest text column available in all supported RDBMS is
   # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
@@ -9,7 +9,7 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
   TEXT_BYTES = 1_073_741_823
 
   def change
-    create_table :versions<%= versions_table_options %><%= version_table_primary_key_type %> do |t|
+    create_table :<%= table_name %><%= versions_table_options %><%= version_table_primary_key_type %> do |t|
       # Consider using bigint type for performance if you are going to store only numeric ids.
       # t.bigint   :whodunnit
       t.string   :whodunnit
@@ -36,6 +36,6 @@ class CreateVersions < ActiveRecord::Migration<%= migration_version %>
       t.string   :event,     null: false
       t.text     :object, limit: TEXT_BYTES
     end
-    add_index :versions, %i[item_type item_id]
+    add_index :<%= table_name %>, %i[item_type item_id]
   end
 end

--- a/lib/generators/paper_trail/migration_generator.rb
+++ b/lib/generators/paper_trail/migration_generator.rb
@@ -8,6 +8,10 @@ module PaperTrail
   class MigrationGenerator < ::Rails::Generators::Base
     include ::Rails::Generators::Migration
 
+    # Define arguments for the generator
+    argument :version_class_name, type: :string, default: "Version",
+             desc: "The name of the Version class (e.g., CommentVersion)"
+
     def self.next_migration_number(dirname)
       ::ActiveRecord::Generators::Base.next_migration_number(dirname)
     end
@@ -19,10 +23,17 @@ module PaperTrail
       if self.class.migration_exists?(migration_dir, template)
         ::Kernel.warn "Migration already exists: #{template}"
       else
+        # Map the dynamic template name to the actual template file
+        template_file = map_template_name(template)
+
         migration_template(
-          "#{template}.rb.erb",
+          "#{template_file}.rb.erb",
           "db/migrate/#{template}.rb",
-          { migration_version: migration_version }.merge(extra_options)
+          {
+            migration_version: migration_version,
+            table_name: table_name,
+            version_class_name: version_class_name
+          }.merge(extra_options)
         )
       end
     end
@@ -33,6 +44,22 @@ module PaperTrail
         ActiveRecord::VERSION::MAJOR,
         ActiveRecord::VERSION::MINOR
       )
+    end
+
+    # Convert Version class name to table name using Rails conventions
+    def table_name
+      version_class_name.underscore.pluralize
+    end
+
+    # Map the dynamic template name to the actual template file
+    def map_template_name(template)
+      if template.start_with?("create_")
+        "create_versions"
+      elsif template.start_with?("add_object_changes_to_")
+        "add_object_changes_to_versions"
+      else
+        template
+      end
     end
   end
 end

--- a/spec/generators/paper_trail/install_generator_spec.rb
+++ b/spec/generators/paper_trail/install_generator_spec.rb
@@ -139,4 +139,82 @@ RSpec.describe PaperTrail::InstallGenerator, type: :generator do
       )
     end
   end
+
+  describe "with custom version class name" do
+    before do
+      prepare_destination
+      run_generator %w[CommentVersion]
+    end
+
+    it "generates a migration with the correct filename and content for the custom table" do
+      expected_parent_class = lambda {
+        old_school = "ActiveRecord::Migration"
+        ar_version = ActiveRecord::VERSION
+        format("%s[%d.%d]", old_school, ar_version::MAJOR, ar_version::MINOR)
+      }.call
+
+      expect(destination_root).to(
+        have_structure {
+          directory("db") {
+            directory("migrate") {
+              migration("create_comment_versions") {
+                contains("class CreateCommentVersions < " + expected_parent_class)
+                contains "def change"
+                contains "create_table :comment_versions"
+                contains "add_index :comment_versions, %i[item_type item_id]"
+              }
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe "with custom version class name and `--with-changes`" do
+    before do
+      prepare_destination
+      run_generator %w[ProductVersion --with-changes]
+    end
+
+    it "generates migrations with correct filenames and content for the custom table" do
+      expect(destination_root).to(
+        have_structure {
+          directory("db") {
+            directory("migrate") {
+              migration("create_product_versions") {
+                contains "class CreateProductVersions"
+                contains "create_table :product_versions"
+              }
+              migration("add_object_changes_to_product_versions") {
+                contains "class AddObjectChangesToProductVersions"
+                contains "add_column :product_versions, :object_changes, :text"
+              }
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe "with namespaced custom version class" do
+    before do
+      prepare_destination
+      run_generator %w[Admin::LogVersion]
+    end
+
+    it "handles namespaced class names correctly with proper filenames" do
+      expect(destination_root).to(
+        have_structure {
+          directory("db") {
+            directory("migrate") {
+              migration("create_admin_log_versions") {
+                contains "class CreateAdminLogVersions"
+                contains "create_table :admin_log_versions"
+              }
+            }
+          }
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
My team and I decided to split the versions table into multiple tables for better separation.
When trying to do so we noticed that there is no generator options for a custom table name and we have to rename each migration manually. We figured that adding an optional argument to the migration generator will fix this and provide a small QOL improvement.

Example from USAGE file:
```
rails generate paper_trail:install CommentVersion
=>  db/migrate/[TIMESTAMP]_create_comment_versions.rb
```

Check the following boxes:

- [x] Wrote [good commit messages][1].
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new 
  code introduces user-observable changes.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
